### PR TITLE
fix(tab-bar): keep all tabs visible

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
@@ -42,7 +42,6 @@ struct MainTabView: View {
             }
             .environment(\.symbolVariants, .none)
             .tint(Color.accentIndigo)
-            .tabBarMinimizeBehavior(.onScrollDown)
             .environment(viewModel)
             .environment(dashboardViewModel)
             .environment(profileViewModel)


### PR DESCRIPTION
## Summary
- Removes `.tabBarMinimizeBehavior(.onScrollDown)` from `MainTabView`, which was collapsing the tab bar to a single floating home button on scroll

## Test plan
- [ ] Launch the app and scroll down on any tab — Home, Activity, and Insights should remain visible in the tab bar