### PR TITLE
Delete All Data + empty-state UX fixes

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
@@ -44,9 +44,19 @@ struct PersonalFinanceTrakerApp: App {
                 configurations: [modelConfiguration]
             )
             
-            #if DEBUG
-            setupSampleDataIfNeeded(in: container)
-            #endif
+            // Disabled: was auto-reseeding sample transactions on every debug launch
+            // with an empty database, which masked Delete All Data / clean-import
+            // testing. CSV import now covers getting data into a fresh debug build;
+            // re-enable if we need instant sample data again (e.g. for previews
+            // without CSV).
+            // #if DEBUG
+            // setupSampleDataIfNeeded(in: container)
+            // #endif
+
+            // Default categories are real app data (not sample data) — every user,
+            // debug or release, needs them to add a transaction. Always reseed when
+            // empty, including right after Delete All Data wipes CategoryModel.
+            seedDefaultCategoriesIfNeeded(in: container)
 
             return container
         } catch {
@@ -72,6 +82,19 @@ private extension PersonalFinanceTrakerApp {
         let key = "member_since_timestamp"
         guard UserDefaults.standard.double(forKey: key) == 0 else { return }
         UserDefaults.standard.set(Date.now.timeIntervalSince1970, forKey: key)
+    }
+
+    /// Seeds the default expense/income categories if none exist yet.
+    /// - Parameter container: The model container to populate
+    static func seedDefaultCategoriesIfNeeded(in container: ModelContainer) {
+        let context = container.mainContext
+        let count = (try? context.fetchCount(FetchDescriptor<CategoryModel>())) ?? 0
+        guard count == 0 else { return }
+
+        for category in SampleData.createSampleCategories() {
+            context.insert(category)
+        }
+        try? context.save()
     }
 
     /// Sets up sample data in debug builds if no existing data is found

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Assets.xcassets/textDim.colorset/Contents.json
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Assets.xcassets/textDim.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.545",
-          "green" : "0.455",
-          "red" : "0.392"
+          "blue" : "0.590",
+          "green" : "0.500",
+          "red" : "0.440"
         }
       },
       "idiom" : "universal"

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
@@ -17,6 +17,15 @@ struct DashboardView: View {
                 VStack(spacing: 20) {
                     GreetingHeaderView()
                     BalanceCardView()
+                    if viewModel.hasNoTransactions {
+                        EmptyStateView(
+                            icon: "plus.circle",
+                            message: "Add your first transaction",
+                            subtitle: "Track an expense or income to see your balance grow.",
+                            actionTitle: "Add Transaction",
+                            action: { showingAddItemView = true }
+                        )
+                    }
                     if !viewModel.recentTransactions.isEmpty {
                         RecentTransactionsSectionView()
                     }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardViewModel.swift
@@ -109,4 +109,8 @@ final class DashboardViewModel {
         return "This period · \(startFormatted) – \(endFormatted)"
     }
 
+    var hasNoTransactions: Bool {
+        transactions.isEmpty
+    }
+
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/GoalsSection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/GoalsSection.swift
@@ -30,22 +30,11 @@ struct GoalsSection: View {
             }
 
             if goals.isEmpty {
-                GlassCard {
-                    VStack(spacing: 8) {
-                        Image(systemName: "flag.fill")
-                            .font(.title2)
-                            .foregroundStyle(.accentIndigo.opacity(0.6))
-                        Text("Set your first goal")
-                            .font(.subheadline.bold())
-                            .foregroundStyle(.textMid)
-                        Text("Trip fund, emergency buffer, dream purchase — make it visual.")
-                            .font(.caption)
-                            .foregroundStyle(.textDim)
-                            .multilineTextAlignment(.center)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                }
+                EmptyStateView(
+                    icon: "flag.fill",
+                    message: "Set your first goal",
+                    subtitle: "Trip fund, emergency buffer, dream purchase — make it visual."
+                )
             } else {
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                     ForEach(goals) { goal in

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/HealthScoreSection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/HealthScoreSection.swift
@@ -22,6 +22,12 @@ struct HealthScoreSection: View {
                 HealthScoreCard(healthScore: score, snapshots: snapshots) {
                     showingDetail = true
                 }
+            } else {
+                EmptyStateView(
+                    icon: "gauge.medium",
+                    message: "Add transactions to unlock your Health Score",
+                    subtitle: "Your score builds from at least a few weeks of activity."
+                )
             }
         }
         .sheet(isPresented: $showingDetail) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/InsightsEmptyCard.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/InsightsEmptyCard.swift
@@ -1,26 +1,52 @@
 import SwiftUI
 
-struct InsightsEmptyCard: View {
+/// Shared empty-state card: optional icon + message + optional subtitle + optional CTA button.
+/// Used across Home, Activity, and Insights for consistent "nothing here yet" messaging.
+/// ponytail: kept the name InsightsEmptyCard (originally Insights-only) as a typealias so
+/// existing call sites (HabitsSection, ForecastSection, CategoryTrendsSection) don't need edits.
+struct EmptyStateView: View {
+    var icon: String? = nil
     let message: String
     var subtitle: String? = nil
+    var actionTitle: String? = nil
+    var action: (() -> Void)? = nil
 
     var body: some View {
         GlassCard {
-            VStack(spacing: 4) {
+            VStack(spacing: 8) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .foregroundStyle(.accentIndigo.opacity(0.6))
+                }
                 Text(message)
-                    .font(.subheadline)
-                    .foregroundStyle(.textDim)
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.textMid)
                     .frame(maxWidth: .infinity)
                     .multilineTextAlignment(.center)
                 if let subtitle {
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundStyle(.textDim.opacity(0.7))
+                        .foregroundStyle(.textDim)
                         .frame(maxWidth: .infinity)
                         .multilineTextAlignment(.center)
                 }
+                if let actionTitle, let action {
+                    Button(action: action) {
+                        Text(actionTitle)
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.textPrimary)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 10)
+                            .glassEffect(.regular.tint(Color.accentIndigo).interactive())
+                    }
+                    .padding(.top, 4)
+                }
             }
+            .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
         }
     }
 }
+
+typealias InsightsEmptyCard = EmptyStateView

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/SpendingTimelineChart.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/SpendingTimelineChart.swift
@@ -30,13 +30,10 @@ struct SpendingTimelineChart: View {
                     .frame(maxWidth: 200)
             }
 
-            GlassCard {
-                if data.isEmpty || data.allSatisfy({ $0.expenses == 0 }) {
-                    Text("No data")
-                        .foregroundStyle(.textDim)
-                        .frame(height: 200)
-                        .frame(maxWidth: .infinity)
-                } else {
+            if data.isEmpty || data.allSatisfy({ $0.expenses == 0 }) {
+                EmptyStateView(message: "No spending data yet")
+            } else {
+                GlassCard {
                     Chart {
                         ForEach(data) { point in
                             AreaMark(

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/InsightsViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/InsightsViewModel.swift
@@ -155,13 +155,27 @@ final class CompassViewModel {
 
     private func computeHealthScore() async {
         let budgetedCategories = (try? await repo.fetchCategories())?.filter { $0.monthlyBudget != nil } ?? []
-        healthScore = healthService.compute(
-            transactions: transactions,
-            expenseTransactions: expenseTransactions,
-            budgetedCategories: budgetedCategories,
-            payCycleStartDay: AppSettings.storedStartDay,
-            ignoreSubscriptions: ignoreSubscriptions
-        )
+
+        // ponytail: Require at least some income or expense in the 6-month window.
+        // Could later be tightened (e.g., N transactions minimum) if all-zero turns out too lenient.
+        let calendar = Calendar.current
+        let now = Date.now
+        let financialMonths = PayCycleService.financialMonths(count: 6, before: now, startDay: AppSettings.storedStartDay, calendar: calendar)
+        let sixMonthsAgo = financialMonths.first?.start ?? calendar.date(byAdding: .month, value: -6, to: now) ?? now
+        let hasRecentIncome = transactions.contains { $0.timestamp >= sixMonthsAgo && $0.amount > 0 }
+        let hasRecentExpense = expenseTransactions.contains { $0.timestamp >= sixMonthsAgo }
+
+        if !hasRecentIncome && !hasRecentExpense {
+            healthScore = nil
+        } else {
+            healthScore = healthService.compute(
+                transactions: transactions,
+                expenseTransactions: expenseTransactions,
+                budgetedCategories: budgetedCategories,
+                payCycleStartDay: AppSettings.storedStartDay,
+                ignoreSubscriptions: ignoreSubscriptions
+            )
+        }
         await saveSnapshotIfNeeded()
         scoreSnapshots = (try? await repo.fetchSnapshots(limit: 6)) ?? []
     }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -59,11 +59,10 @@ final class ProfileViewModel {
     var greeting: String {
         let hour = Calendar.current.component(.hour, from: Date.now)
         let firstName = fullName.split(separator: " ").first.map(String.init) ?? ""
-        let name = firstName.isEmpty ? "there" : firstName
         let salutation: String
         if hour < 12 { salutation = "Good morning" }
         else if hour < 17 { salutation = "Good afternoon" }
         else { salutation = "Good evening" }
-        return "\(salutation), \(name)"
+        return firstName.isEmpty ? salutation : "\(salutation), \(firstName)"
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -7,6 +7,7 @@ struct ProfileView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(TransactionListViewModel.self) private var transactionViewModel: TransactionListViewModel
+    @Environment(DataChangedSignal.self) private var dataChanged
     @State private var showingFileImporter = false
     @State private var showingDeleteConfirmation = false
     @State private var showingPINConfirmation = false
@@ -55,6 +56,7 @@ struct ProfileView: View {
                             showingDeleteConfirmation = true
                         } label: {
                             Label("Delete All Data", systemImage: "trash")
+                                .foregroundStyle(.negative)
                         }
                     } header: {
                         Text("DATA")
@@ -141,6 +143,16 @@ struct ProfileView: View {
     private func performWipe() {
         do {
             try DataWipeService.wipeAllData(context: modelContext)
+            // Categories are core app data (needed to add a transaction), not sample
+            // data — reseed immediately so the user isn't stuck until next launch.
+            for category in SampleData.createSampleCategories() {
+                modelContext.insert(category)
+            }
+            try modelContext.save()
+            // DashboardViewModel/TransactionListViewModel cache their own in-memory
+            // arrays; bump the shared signal so MainTabView reloads them (same
+            // pattern EditAddTransactionView uses after a save/delete).
+            dataChanged.bump()
             showingDeleteSuccess = true
         } catch {
             deleteErrorMessage = error.localizedDescription

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -1,11 +1,18 @@
 import SwiftUI
+import SwiftData
 
 struct ProfileView: View {
     @Bindable var viewModel: ProfileViewModel
     @Binding var selectedDetent: PresentationDetent
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
     @Environment(TransactionListViewModel.self) private var transactionViewModel: TransactionListViewModel
     @State private var showingFileImporter = false
+    @State private var showingDeleteConfirmation = false
+    @State private var showingPINConfirmation = false
+    @State private var showingDeleteSuccess = false
+    @State private var deleteErrorMessage: String?
+    private let pinService = PINService()
 
     var body: some View {
         NavigationStack {
@@ -43,6 +50,12 @@ struct ProfileView: View {
                             }
                         }
                         .disabled(transactionViewModel.isLoadingCSV)
+
+                        Button(role: .destructive) {
+                            showingDeleteConfirmation = true
+                        } label: {
+                            Label("Delete All Data", systemImage: "trash")
+                        }
                     } header: {
                         Text("DATA")
                             .font(.caption.weight(.semibold))
@@ -88,6 +101,49 @@ struct ProfileView: View {
                     transactionViewModel.importError = error.localizedDescription
                 }
             }
+            .alert("Delete All Data?", isPresented: $showingDeleteConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Delete", role: .destructive) {
+                    if pinService.isPINSet() {
+                        showingPINConfirmation = true
+                    } else {
+                        performWipe()
+                    }
+                }
+            } message: {
+                Text("This will permanently erase every transaction, category, credit card, and goal. This cannot be undone.")
+            }
+            .sheet(isPresented: $showingPINConfirmation) {
+                PINConfirmationView(
+                    viewModel: PINConfirmationViewModel(pinService: pinService) {
+                        showingPINConfirmation = false
+                        performWipe()
+                    }
+                )
+            }
+            .alert("All Data Deleted", isPresented: $showingDeleteSuccess) {
+                Button("OK") { dismiss() }
+            }
+            .alert(
+                "Delete Failed",
+                isPresented: Binding(
+                    get: { deleteErrorMessage != nil },
+                    set: { if !$0 { deleteErrorMessage = nil } }
+                )
+            ) {
+                Button("OK") { deleteErrorMessage = nil }
+            } message: {
+                Text(deleteErrorMessage ?? "")
+            }
+        }
+    }
+
+    private func performWipe() {
+        do {
+            try DataWipeService.wipeAllData(context: modelContext)
+            showingDeleteSuccess = true
+        } catch {
+            deleteErrorMessage = error.localizedDescription
         }
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINConfirmationView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINConfirmationView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct PINConfirmationView: View {
+    @State var viewModel: PINConfirmationViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            MonkeyAnimationView(
+                eyesOpen: $viewModel.eyesOpen,
+                isShaking: viewModel.isShaking
+            )
+            .padding(.bottom, 32)
+
+            VStack(spacing: 8) {
+                Text("Confirm your PIN")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.textPrimary)
+
+                if !viewModel.errorMessage.isEmpty {
+                    Text(viewModel.errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.negative)
+                        .transition(.opacity)
+                        .animation(.easeInOut, value: viewModel.errorMessage)
+                }
+            }
+            .padding(.bottom, 32)
+
+            PINDotsView(filledCount: viewModel.pinInput.count)
+                .padding(.bottom, 48)
+
+            PINPadView(
+                onDigit: { viewModel.appendDigit($0) },
+                onDelete: { viewModel.deleteDigit() }
+            )
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .appBackground()
+        .preferredColorScheme(.dark)
+    }
+}
+
+#Preview {
+    PINConfirmationView(viewModel: PINConfirmationViewModel(pinService: PINService(), onConfirmed: {}))
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+@Observable @MainActor
+final class PINConfirmationViewModel {
+    var pinInput: String = ""
+    var isShaking: Bool = false
+    var eyesOpen: Bool = true
+    var errorMessage: String = ""
+
+    private let pinService: PINService
+    private let onConfirmed: () -> Void
+
+    init(pinService: PINService, onConfirmed: @escaping () -> Void) {
+        self.pinService = pinService
+        self.onConfirmed = onConfirmed
+    }
+
+    func appendDigit(_ digit: String) {
+        guard pinInput.count < 4 else { return }
+        pinInput += digit
+        eyesOpen = false
+        if pinInput.count == 4 {
+            Task { try? await Task.sleep(for: .seconds(0.15)); self.verifyPIN() }
+        }
+    }
+
+    func deleteDigit() {
+        if !pinInput.isEmpty { pinInput.removeLast() }
+        eyesOpen = pinInput.isEmpty
+    }
+
+    private func verifyPIN() {
+        if pinService.validatePIN(pinInput) {
+            onConfirmed()
+        } else {
+            errorMessage = "Incorrect PIN. Try again."
+            triggerShake()
+            Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
+        }
+    }
+
+    private func triggerShake() {
+        isShaking = true
+        Task { try? await Task.sleep(for: .seconds(0.5)); self.isShaking = false }
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/ActivityView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/ActivityView.swift
@@ -20,16 +20,26 @@ struct ActivityView: View {
         return NavigationStack {
             List {
                 Section {
-                    FilterChipsView()
-                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 8, trailing: 16))
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
+                    if !viewModel.hasNoTransactions {
+                        FilterChipsView()
+                            .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 8, trailing: 16))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    }
 
                     if viewModel.totalFilteredIncome == 0 && viewModel.totalFilteredExpenses == 0 {
-                        Text("No transactions yet")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal)
+                        if viewModel.hasNoTransactions {
+                            EmptyStateView(
+                                icon: "tray",
+                                message: "No transactions yet",
+                                subtitle: "Add your first transaction to start tracking.",
+                                actionTitle: "Add Transaction",
+                                action: { showingAddItemView = true }
+                            )
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                        }
                     } else {
                         HStack(spacing: 12) {
                             StatCard(
@@ -85,7 +95,11 @@ struct ActivityView: View {
             .appBackground()
             .navigationTitle("Activity")
             .navigationBarTitleDisplayMode(.large)
-            .searchable(text: $viewModel.searchText, prompt: "Search transactions...")
+            .modifier(ConditionalSearchable(
+                isActive: !viewModel.hasNoTransactions,
+                text: $viewModel.searchText,
+                prompt: "Search transactions..."
+            ))
             .appToolbar(showingAddItemView: $showingAddItemView)
             .overlay {
                 if groupedFiltered.isEmpty && (!viewModel.searchText.isEmpty || viewModel.filters.isActive) {
@@ -105,6 +119,19 @@ struct ActivityView: View {
     }
 }
 
+private struct ConditionalSearchable: ViewModifier {
+    let isActive: Bool
+    @Binding var text: String
+    let prompt: String
+
+    func body(content: Content) -> some View {
+        if isActive {
+            content.searchable(text: $text, prompt: prompt)
+        } else {
+            content
+        }
+    }
+}
 
 #Preview {
     let schema = Schema([TransactionModel.self, CategoryModel.self])

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/TransactionListViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/TransactionListViewModel.swift
@@ -11,6 +11,7 @@ import SwiftData
 @Observable @MainActor
 final class TransactionListViewModel {
     var transactions: [TransactionSnapshot] = []
+    var hasNoTransactions: Bool { transactions.isEmpty }
     var filteredItems: [TransactionSnapshot] = [] {
         didSet {
             updateGroupedItems()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AppToolbarModifier.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AppToolbarModifier.swift
@@ -30,6 +30,7 @@ struct AppToolbarModifier: ViewModifier {
                     }
                     .font(.headline)
                     .foregroundStyle(.textPrimary)
+                    .glassEffect(.regular.tint(Color.accentIndigo).interactive())
                 }
             }
             .sheet(isPresented: $showingProfile) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/DataWipeService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/DataWipeService.swift
@@ -1,0 +1,13 @@
+import SwiftData
+
+enum DataWipeService {
+    static func wipeAllData(context: ModelContext) throws {
+        try context.delete(model: TransactionModel.self)
+        try context.delete(model: CategoryModel.self)
+        try context.delete(model: CreditCardModel.self)
+        try context.delete(model: GoalModel.self)
+        try context.delete(model: HealthScoreSnapshot.self)
+        try context.delete(model: DailyForecastCache.self)
+        try context.save()
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Insights/CompassViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Insights/CompassViewModelTests.swift
@@ -1,0 +1,48 @@
+import Testing
+import Foundation
+@testable import PersonalFinanceTraker
+
+@MainActor
+@Suite(.serialized)
+struct CompassViewModelTests {
+
+    private func makeVM(transactions: [TransactionSnapshot]) async -> CompassViewModel {
+        let repo = MockTransactionRepository()
+        repo.stubbedTransactions = transactions
+        let vm = CompassViewModel(repo: repo)
+        vm.load()
+        // Wait for async load to complete
+        try? await Task.sleep(for: .milliseconds(100))
+        return vm
+    }
+
+    private func makeIncome(amount: Decimal, monthsAgo: Int = 0) -> TransactionSnapshot {
+        let date = Calendar.current.date(byAdding: .month, value: -monthsAgo, to: Date()) ?? Date()
+        return .test(timestamp: date, amount: amount, category: "Salary")
+    }
+
+    private func makeExpense(amount: Decimal, category: String = "Groceries", monthsAgo: Int = 0) -> TransactionSnapshot {
+        let date = Calendar.current.date(byAdding: .month, value: -monthsAgo, to: Date()) ?? Date()
+        return .test(timestamp: date, amount: -abs(amount), category: category)
+    }
+
+    @Test("healthScore is nil when no income and no expenses in recent 6 months")
+    func healthScoreNilWithoutRecentTransactions() async {
+        let vm = await makeVM(transactions: [])
+        #expect(vm.healthScore == nil)
+    }
+
+    @Test("healthScore is not nil when income exists in recent 6 months")
+    func healthScoreNotNilWithRecentIncome() async {
+        let income = makeIncome(amount: 1000, monthsAgo: 0)
+        let vm = await makeVM(transactions: [income])
+        #expect(vm.healthScore != nil)
+    }
+
+    @Test("healthScore is not nil when expenses exist in recent 6 months")
+    func healthScoreNotNilWithRecentExpense() async {
+        let expense = makeExpense(amount: 100, monthsAgo: 0)
+        let vm = await makeVM(transactions: [expense])
+        #expect(vm.healthScore != nil)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+
+@testable import PersonalFinanceTraker
+
+@MainActor
+struct PINConfirmationViewModelTests {
+    private let pinService = PINService()
+
+    @Test("Correct PIN entered digit-by-digit invokes onConfirmed callback")
+    func correctPINEntered() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        var onConfirmedCalled = false
+        let viewModel = PINConfirmationViewModel(pinService: pinService) {
+            onConfirmedCalled = true
+        }
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+        viewModel.appendDigit("4")
+
+        #expect(viewModel.pinInput == "1234")
+        #expect(!onConfirmedCalled)
+
+        try await Task.sleep(for: .seconds(0.3))
+
+        #expect(onConfirmedCalled)
+        #expect(viewModel.errorMessage.isEmpty)
+    }
+
+    @Test("Incorrect PIN entered does not invoke onConfirmed")
+    func incorrectPINEntered() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        var onConfirmedCalled = false
+        let viewModel = PINConfirmationViewModel(pinService: pinService) {
+            onConfirmedCalled = true
+        }
+
+        viewModel.appendDigit("5")
+        viewModel.appendDigit("6")
+        viewModel.appendDigit("7")
+        viewModel.appendDigit("8")
+
+        #expect(viewModel.pinInput == "5678")
+
+        try await Task.sleep(for: .seconds(0.3))
+
+        #expect(!onConfirmedCalled)
+        #expect(!viewModel.errorMessage.isEmpty)
+        #expect(viewModel.isShaking)
+
+        try await Task.sleep(for: .seconds(0.3))
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+    }
+
+    @Test("appendDigit does not append beyond 4 digits")
+    func appendDigitBoundary() {
+        var onConfirmedCalled = false
+        let viewModel = PINConfirmationViewModel(pinService: pinService) {
+            onConfirmedCalled = true
+        }
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+        viewModel.appendDigit("4")
+        viewModel.appendDigit("5")
+
+        #expect(viewModel.pinInput == "1234")
+        #expect(viewModel.pinInput.count == 4)
+    }
+
+    @Test("deleteDigit removes last digit and updates eyesOpen")
+    func deleteDigit() {
+        var onConfirmedCalled = false
+        let viewModel = PINConfirmationViewModel(pinService: pinService) {
+            onConfirmedCalled = true
+        }
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+
+        #expect(viewModel.pinInput == "123")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput == "12")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput == "1")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/DataWipeServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/DataWipeServiceTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import PersonalFinanceTraker
+
+@Suite(.serialized)
+struct DataWipeServiceTests {
+
+    private func makeSeededContext() -> ModelContext {
+        let schema = Schema([
+            TransactionModel.self,
+            CategoryModel.self,
+            CreditCardModel.self,
+            GoalModel.self,
+            HealthScoreSnapshot.self,
+            DailyForecastCache.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let context = ModelContext(container)
+
+        // Categories + transactions via the app's existing sample data
+        SampleData.populateModelContext(context)
+
+        // One instance of each of the remaining models
+        context.insert(CreditCardModel(name: "Test Card", lastFour: "1234", balance: 100, limit: 1000))
+        context.insert(GoalModel(name: "Test Goal", targetAmount: 500))
+        context.insert(HealthScoreSnapshot(
+            timestamp: .now, score: 80, savingsScore: 80,
+            stabilityScore: 80, adherenceScore: 80, subscriptionScore: 80
+        ))
+        context.insert(DailyForecastCache(monthKey: "2026-07", computedUpToDay: 1, days: [1], amounts: [10]))
+        try! context.save()
+
+        return context
+    }
+
+    @Test("wipeAllData removes every model type")
+    func wipesAllModels() throws {
+        let context = makeSeededContext()
+
+        // Sanity check: seeded data exists before wiping
+        #expect(try context.fetchCount(FetchDescriptor<TransactionModel>()) > 0)
+        #expect(try context.fetchCount(FetchDescriptor<CategoryModel>()) > 0)
+        #expect(try context.fetchCount(FetchDescriptor<CreditCardModel>()) > 0)
+        #expect(try context.fetchCount(FetchDescriptor<GoalModel>()) > 0)
+        #expect(try context.fetchCount(FetchDescriptor<HealthScoreSnapshot>()) > 0)
+        #expect(try context.fetchCount(FetchDescriptor<DailyForecastCache>()) > 0)
+
+        try DataWipeService.wipeAllData(context: context)
+
+        #expect(try context.fetchCount(FetchDescriptor<TransactionModel>()) == 0)
+        #expect(try context.fetchCount(FetchDescriptor<CategoryModel>()) == 0)
+        #expect(try context.fetchCount(FetchDescriptor<CreditCardModel>()) == 0)
+        #expect(try context.fetchCount(FetchDescriptor<GoalModel>()) == 0)
+        #expect(try context.fetchCount(FetchDescriptor<HealthScoreSnapshot>()) == 0)
+        #expect(try context.fetchCount(FetchDescriptor<DailyForecastCache>()) == 0)
+    }
+
+    @Test("wipeAllData is idempotent on an already-empty context")
+    func wipingEmptyContextDoesNotThrow() throws {
+        let context = makeSeededContext()
+        try DataWipeService.wipeAllData(context: context)
+
+        // Calling again on an already-empty store must not throw
+        try DataWipeService.wipeAllData(context: context)
+
+        #expect(try context.fetchCount(FetchDescriptor<TransactionModel>()) == 0)
+    }
+}

--- a/docs/superpowers/specs/2026-07-20-delete-all-data-design.md
+++ b/docs/superpowers/specs/2026-07-20-delete-all-data-design.md
@@ -1,0 +1,114 @@
+# Delete All Data — Design
+
+## Problem
+
+Users have no way to clear their financial data short of deleting and reinstalling the
+app. We need an in-app "Delete All Data" action for a fresh start without losing PIN /
+biometric setup or profile preferences.
+
+## Scope
+
+**Wiped:** the 6 SwiftData models that make up financial data —
+`TransactionModel`, `CategoryModel`, `CreditCardModel`, `GoalModel`,
+`HealthScoreSnapshot`, `DailyForecastCache`.
+
+**Kept:** PIN (Keychain), biometric-lock setting, full name, currency, pay-cycle
+preference, and the `member_since_timestamp`. This is a data wipe, not a factory
+reset — the app stays configured, just empty.
+
+## Entry point
+
+`Features/Profile/Views/ProfileView.swift` already has a "DATA" section containing
+"Import CSV". Add a new row directly below it:
+
+```swift
+Button(role: .destructive) {
+    showDeleteConfirmation = true
+} label: {
+    Label("Delete All Data", systemImage: "trash")
+}
+```
+
+## Flow
+
+1. **Tap "Delete All Data"** → destructive `.alert`:
+   - Title: "Delete All Data?"
+   - Message: "This will permanently erase every transaction, category, credit
+     card, and goal. This cannot be undone."
+   - Actions: "Cancel" (`.cancel`), "Delete" (`.destructive`)
+
+2. **On "Delete"**: check `PINService().isPINSet()`.
+   - **PIN set** → present a new `PINConfirmationView` as a sheet. The user must
+     enter their existing PIN correctly before the wipe proceeds.
+   - **No PIN set** → skip straight to step 3.
+
+3. **Execute wipe**: call `DataWipeService.wipeAllData(context:)`, which batch-deletes
+   each of the 6 model types from the shared `ModelContext` and saves.
+
+4. **Feedback**: on success, show a confirmation alert ("All data deleted") and
+   dismiss back to the Settings sheet. On failure, show an alert with the
+   underlying error message (mirrors the existing `transactionViewModel.importError`
+   pattern already used for CSV import failures in `ProfileView`).
+
+Dashboard, Activity, and Insights are all SwiftData `@Query`-driven, so they show
+their existing empty states automatically once the wipe completes — no additional
+UI work needed there.
+
+## PIN confirmation (new, lightweight)
+
+`PINEntryViewModel` is tightly coupled to the app-unlock flow (`BiometricAuthService`,
+`authService.unlock()`) — reusing it directly for a one-off confirmation would drag in
+unrelated unlock semantics. Instead:
+
+- **New `PINConfirmationViewModel`** (`Features/Security/ViewModels/`): holds
+  `pinInput`, `isShaking`, `eyesOpen`, `errorMessage`, and a completion closure
+  `onConfirmed: () -> Void`. `verifyPIN()` calls `PINService().validatePIN(_:)` and
+  invokes the closure on success, or shakes + clears on failure — no interaction with
+  `BiometricAuthService` at all.
+- **New `PINConfirmationView`** (`Features/Security/`): visually mirrors
+  `PINEntryView` (same `MonkeyAnimationView` / `PINDotsView` / `PINPadView`
+  components, same `.appBackground()` styling) but with the title "Confirm your PIN"
+  and no biometric/"Forgot PIN" affordances — this is a confirmation step, not a lock
+  screen.
+
+## DataWipeService (new)
+
+`Utilities/DataWipeService.swift`:
+
+```swift
+enum DataWipeService {
+    static func wipeAllData(context: ModelContext) throws {
+        try context.delete(model: TransactionModel.self)
+        try context.delete(model: CategoryModel.self)
+        try context.delete(model: CreditCardModel.self)
+        try context.delete(model: GoalModel.self)
+        try context.delete(model: HealthScoreSnapshot.self)
+        try context.delete(model: DailyForecastCache.self)
+        try context.save()
+    }
+}
+```
+
+Kept as a standalone enum (not a class/service with dependencies) so it's trivially
+testable and reusable — this is the only piece of real logic in the feature.
+
+## Files
+
+- NEW `Utilities/DataWipeService.swift`
+- NEW `Features/Security/PINConfirmationView.swift`
+- NEW `Features/Security/ViewModels/PINConfirmationViewModel.swift`
+- EDIT `Features/Profile/Views/ProfileView.swift` — add the button, alert, and sheet
+  presentation wiring
+- NEW `PersonalFinanceTrakerTests/DataWipeServiceTests.swift`
+
+## Testing
+
+`DataWipeServiceTests` (Swift Testing, `@testable import PersonalFinanceTraker`):
+- Build an in-memory `ModelContainer`, seed it via `SampleData.populateModelContext`.
+- Call `DataWipeService.wipeAllData(context:)`.
+- Assert `FetchDescriptor` for each of the 6 model types returns an empty array.
+- Assert no error is thrown when called again on an already-empty context (idempotent).
+
+No UI tests — the alert/sheet flow is straightforward SwiftUI wiring; a manual
+simulator pass (delete with PIN set, delete with no PIN, cancel at each step) is the
+verification for that part.


### PR DESCRIPTION
## Summary
- Adds a PIN-gated "Delete All Data" action in Settings, backed by `DataWipeService` that batch-deletes all financial data and reseeds default categories/refreshes cached view models afterward.
- Fixes a UX audit finding: Insights Health Score previously showed a fake 75/100 (Stability/Budget/Subscriptions defaulted to full marks) with zero transactions — now shows a locked placeholder until there's real activity.
- Adds a shared `EmptyStateView` reused across Home, Activity, and Insights for consistent empty-state messaging with optional CTAs.
- Hides Activity's search bar and filter chips when there are no transactions to act on.
- Adds an onboarding CTA on Home when there are no transactions, fixes the "Good evening, there" greeting fallback, and emphasizes the "+" add-transaction button as the primary action.
- Bumps muted-text contrast for WCAG AA.

## Test plan
- [x] `mcp__xcode__BuildProject` — clean build
- [x] `mcp__xcode__RunAllTests` — 210/210 passing (includes new `CompassViewModelTests` covering the Health Score nil/non-nil boundary, and `DataWipeServiceTests`)
- [ ] Manual: verify empty states on a freshly wiped app (Home, Activity, Insights) and confirm Delete All Data flow end-to-end in the simulator/device