### PR TITLE
Budgets: per-category spending limits with pay-cycle-aware tracking

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
@@ -1,0 +1,49 @@
+//  BudgetRow.swift
+//  PersonalFinanceTraker
+
+import SwiftUI
+import SwiftData
+
+struct BudgetRow: View {
+    @Bindable var category: CategoryModel
+    @Environment(\.modelContext) private var modelContext
+    @FocusState private var isFocused: Bool
+    @State private var text: String = ""
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: category.systemImage)
+                .foregroundStyle(category.categoryColor)
+                .frame(width: 24)
+            Text(category.name)
+                .foregroundStyle(.textPrimary)
+            Spacer()
+            TextField("No limit", text: $text)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .focused($isFocused)
+                .frame(width: 100)
+                .foregroundStyle(.textPrimary)
+        }
+        .onAppear { text = displayText(for: category.monthlyBudget) }
+        .onChange(of: isFocused) { _, focused in
+            if !focused { commit() }
+        }
+    }
+
+    private func displayText(for budget: Decimal?) -> String {
+        guard let budget, budget > 0 else { return "" }
+        return NSDecimalNumber(decimal: budget).stringValue
+    }
+
+    private func commit() {
+        let normalized = text.replacingOccurrences(of: ",", with: ".")
+        if let value = Decimal(string: normalized), value > 0 {
+            category.monthlyBudget = value
+        } else {
+            category.monthlyBudget = nil
+            text = ""
+        }
+        try? modelContext.save()
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
@@ -6,9 +6,9 @@ import SwiftData
 
 struct BudgetRow: View {
     @Bindable var category: CategoryModel
+    var isFocused: FocusState<PersistentIdentifier?>.Binding
     @Environment(\.modelContext) private var modelContext
     @Environment(DataChangedSignal.self) private var dataChanged
-    @FocusState private var isFocused: Bool
     @State private var text: String = ""
 
     var body: some View {
@@ -19,31 +19,63 @@ struct BudgetRow: View {
             Text(category.name)
                 .foregroundStyle(.textPrimary)
             Spacer()
+            if !rowFocused && hasBudget {
+                Circle()
+                    .fill(.accentIndigo)
+                    .frame(width: 6, height: 6)
+            }
             TextField("No limit", text: $text)
                 .keyboardType(.decimalPad)
                 .multilineTextAlignment(.trailing)
-                .focused($isFocused)
+                .focused(isFocused, equals: category.id)
                 .frame(width: 100)
-                .foregroundStyle(.textPrimary)
+                .foregroundStyle(!rowFocused && hasBudget ? .accentIndigo : .textPrimary)
+                .fontWeight(!rowFocused && hasBudget ? .medium : .regular)
+                .accessibilityLabel("\(category.name) budget")
+                .accessibilityValue(text.isEmpty ? "No limit" : text)
         }
+        .contentShape(Rectangle())
+        .onTapGesture { isFocused.wrappedValue = category.id }
         .onAppear { text = displayText(for: category.monthlyBudget) }
-        .onChange(of: isFocused) { _, focused in
-            if !focused { commit() }
+        .onChange(of: rowFocused) { _, focused in
+            if focused {
+                text = rawText(for: category.monthlyBudget)
+            } else {
+                commit()
+                text = displayText(for: category.monthlyBudget)
+            }
         }
     }
 
+    private var rowFocused: Bool {
+        isFocused.wrappedValue == category.id
+    }
+
+    private var hasBudget: Bool {
+        if let budget = category.monthlyBudget { return budget > 0 }
+        return false
+    }
+
+    /// Formatted for resting display, matching how Dashboard shows the same value.
     private func displayText(for budget: Decimal?) -> String {
+        guard let budget, budget > 0 else { return "" }
+        return budget.formatted(.currency(code: "EUR"))
+    }
+
+    /// Unformatted digits for editing — what `commit()` can parse back.
+    private func rawText(for budget: Decimal?) -> String {
         guard let budget, budget > 0 else { return "" }
         return NSDecimalNumber(decimal: budget).stringValue
     }
 
     private func commit() {
-        let normalized = text.replacingOccurrences(of: ",", with: ".")
-        if let value = Decimal(string: normalized), value > 0 {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            category.monthlyBudget = nil
+        } else if let value = AmountParser.parse(trimmed, requirePositive: true) {
             category.monthlyBudget = value
         } else {
-            category.monthlyBudget = nil
-            text = ""
+            return  // invalid, non-empty: revert — do not touch the model
         }
         try? modelContext.save()
         dataChanged.bump()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetRow.swift
@@ -7,6 +7,7 @@ import SwiftData
 struct BudgetRow: View {
     @Bindable var category: CategoryModel
     @Environment(\.modelContext) private var modelContext
+    @Environment(DataChangedSignal.self) private var dataChanged
     @FocusState private var isFocused: Bool
     @State private var text: String = ""
 
@@ -45,5 +46,6 @@ struct BudgetRow: View {
             text = ""
         }
         try? modelContext.save()
+        dataChanged.bump()
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
@@ -6,21 +6,36 @@ import SwiftData
 
 struct BudgetsView: View {
     @Query(sort: \CategoryModel.name) private var categories: [CategoryModel]
+    @FocusState private var focusedCategoryID: PersistentIdentifier?
 
     private var expenseCategories: [CategoryModel] {
         categories.filter { $0.transactionType == .expense }
+    }
+
+    private var totalBudgeted: Decimal {
+        expenseCategories.compactMap(\.monthlyBudget).filter { $0 > 0 }.reduce(0, +)
     }
 
     var body: some View {
         List {
             Section {
                 ForEach(expenseCategories) { category in
-                    BudgetRow(category: category)
+                    BudgetRow(category: category, isFocused: $focusedCategoryID)
                 }
             } header: {
                 Text("EXPENSE CATEGORIES")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.textDim)
+            } footer: {
+                HStack {
+                    Text("Total budgeted")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.textDim)
+                    Spacer()
+                    Text(totalBudgeted.formatted(.currency(code: "EUR")))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.textPrimary)
+                }
             }
             .appFormSectionBackground()
         }
@@ -28,6 +43,14 @@ struct BudgetsView: View {
         .appBackground()
         .navigationTitle("Budgets")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if focusedCategoryID != nil {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") { focusedCategoryID = nil }
+                }
+            }
+        }
     }
 }
 
@@ -38,5 +61,6 @@ struct BudgetsView: View {
     SampleData.populateModelContext(container.mainContext)
     return NavigationStack { BudgetsView() }
         .modelContainer(container)
+        .environment(DataChangedSignal())
         .preferredColorScheme(.dark)
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
@@ -23,7 +23,7 @@ struct BudgetsView: View {
                     BudgetRow(category: category, isFocused: $focusedCategoryID)
                 }
             } header: {
-                Text("EXPENSE CATEGORIES")
+                Text("MONTHLY BUDGET · EXPENSE CATEGORIES")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.textDim)
             } footer: {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Budgets/BudgetsView.swift
@@ -1,0 +1,42 @@
+//  BudgetsView.swift
+//  PersonalFinanceTraker
+
+import SwiftUI
+import SwiftData
+
+struct BudgetsView: View {
+    @Query(sort: \CategoryModel.name) private var categories: [CategoryModel]
+
+    private var expenseCategories: [CategoryModel] {
+        categories.filter { $0.transactionType == .expense }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(expenseCategories) { category in
+                    BudgetRow(category: category)
+                }
+            } header: {
+                Text("EXPENSE CATEGORIES")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.textDim)
+            }
+            .appFormSectionBackground()
+        }
+        .scrollContentBackground(.hidden)
+        .appBackground()
+        .navigationTitle("Budgets")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    let schema = Schema([TransactionModel.self, CategoryModel.self])
+    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try! ModelContainer(for: schema, configurations: [config])
+    SampleData.populateModelContext(container.mainContext)
+    return NavigationStack { BudgetsView() }
+        .modelContainer(container)
+        .preferredColorScheme(.dark)
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Credit/Components/AddEditCreditCardSheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Credit/Components/AddEditCreditCardSheet.swift
@@ -30,8 +30,8 @@ struct AddEditCreditCardSheet: View {
     var isValid: Bool {
         !name.isEmpty &&
         lastFour.count == 4 &&
-        Decimal(string: balanceText) != nil &&
-        Decimal(string: limitText) != nil
+        AmountParser.parse(balanceText) != nil &&
+        AmountParser.parse(limitText) != nil
     }
 
     var body: some View {
@@ -120,8 +120,8 @@ struct AddEditCreditCardSheet: View {
     }
 
     private func save() {
-        guard let balance = Decimal(string: balanceText),
-              let limit = Decimal(string: limitText) else { return }
+        guard let balance = AmountParser.parse(balanceText),
+              let limit = AmountParser.parse(limitText) else { return }
 
         if let card = cardToEdit {
             card.name = name

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
@@ -34,6 +34,11 @@ struct BudgetProgressBarView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { onTap?() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "\(progress.categoryName), \(progress.spent.formatted(.currency(code: "EUR"))) of \(progress.budget.formatted(.currency(code: "EUR")))\(progress.isOverBudget ? ", over budget" : ", near budget limit")"
+        )
+        .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
@@ -1,0 +1,55 @@
+//  BudgetProgressBarView.swift
+//  PersonalFinanceTraker
+
+import SwiftUI
+import SwiftData
+
+struct BudgetProgressBarView: View {
+    let progress: BudgetProgress
+
+    private var barColor: Color {
+        progress.isOverBudget ? .negative : Color(categoryToken: progress.colorToken)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: progress.systemImage)
+                    .foregroundStyle(Color(categoryToken: progress.colorToken))
+                Text(progress.categoryName)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.textPrimary)
+                Spacer()
+                Text("\(progress.spent.formatted(.currency(code: "EUR"))) / \(progress.budget.formatted(.currency(code: "EUR")))")
+                    .font(.caption)
+                    .foregroundStyle(.textDim)
+            }
+            ProgressView(value: min(progress.percent, 1.0))
+                .tint(barColor)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.bg1)
+        )
+    }
+}
+
+#Preview {
+    let schema = Schema([TransactionModel.self, CategoryModel.self])
+    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try! ModelContainer(for: schema, configurations: [config])
+    let category = CategoryModel(name: "Groceries", systemImage: "cart.fill", type: .expense, colorToken: "categoryGreen", monthlyBudget: 300)
+    container.mainContext.insert(category)
+
+    return BudgetProgressBarView(
+        progress: BudgetProgress(
+            id: category.persistentModelID,
+            categoryName: "Groceries", systemImage: "cart.fill", colorToken: "categoryGreen",
+            budget: 300, spent: 270
+        )
+    )
+    .padding()
+    .appBackground()
+    .preferredColorScheme(.dark)
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift
@@ -6,32 +6,34 @@ import SwiftData
 
 struct BudgetProgressBarView: View {
     let progress: BudgetProgress
+    var onTap: (() -> Void)?
 
     private var barColor: Color {
-        progress.isOverBudget ? .negative : Color(categoryToken: progress.colorToken)
+        if progress.isOverBudget { return .negative }
+        if progress.isNearLimit { return .categoryAmber }
+        return Color(categoryToken: progress.colorToken)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Image(systemName: progress.systemImage)
-                    .foregroundStyle(Color(categoryToken: progress.colorToken))
-                Text(progress.categoryName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.textPrimary)
-                Spacer()
-                Text("\(progress.spent.formatted(.currency(code: "EUR"))) / \(progress.budget.formatted(.currency(code: "EUR")))")
-                    .font(.caption)
-                    .foregroundStyle(.textDim)
+        GlassCard {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Image(systemName: progress.systemImage)
+                        .foregroundStyle(Color(categoryToken: progress.colorToken))
+                    Text(progress.categoryName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.textPrimary)
+                    Spacer()
+                    Text("\(progress.spent.formatted(.currency(code: "EUR"))) / \(progress.budget.formatted(.currency(code: "EUR")))")
+                        .font(.caption)
+                        .foregroundStyle(progress.isOverBudget ? .negative : .textDim)
+                }
+                ProgressView(value: min(progress.percent, 1.0))
+                    .tint(barColor)
             }
-            ProgressView(value: min(progress.percent, 1.0))
-                .tint(barColor)
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(.bg1)
-        )
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
     }
 }
 
@@ -42,13 +44,22 @@ struct BudgetProgressBarView: View {
     let category = CategoryModel(name: "Groceries", systemImage: "cart.fill", type: .expense, colorToken: "categoryGreen", monthlyBudget: 300)
     container.mainContext.insert(category)
 
-    return BudgetProgressBarView(
-        progress: BudgetProgress(
-            id: category.persistentModelID,
-            categoryName: "Groceries", systemImage: "cart.fill", colorToken: "categoryGreen",
-            budget: 300, spent: 270
+    return VStack(spacing: 16) {
+        BudgetProgressBarView(
+            progress: BudgetProgress(
+                id: category.persistentModelID,
+                categoryName: "Groceries", systemImage: "cart.fill", colorToken: "categoryGreen",
+                budget: 300, spent: 270
+            )
         )
-    )
+        BudgetProgressBarView(
+            progress: BudgetProgress(
+                id: category.persistentModelID,
+                categoryName: "Takeout", systemImage: "bag.fill", colorToken: "categoryOrange",
+                budget: 200, spent: 276
+            )
+        )
+    }
     .padding()
     .appBackground()
     .preferredColorScheme(.dark)

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
@@ -56,6 +56,7 @@ struct DashboardView: View {
                 }
                 .padding(16)
             }
+            .safeAreaInset(edge: .top) { Color.clear.frame(height: 44) }
             .appBackground()
             .navigationBarTitleDisplayMode(.inline)
             .appToolbar(showingAddItemView: $showingAddItemView)

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
@@ -22,6 +22,9 @@ struct DashboardView: View {
                             viewModel.dismissAnomaly()
                         }
                     }
+                    ForEach(viewModel.nearLimitBudgets) { progress in
+                        BudgetProgressBarView(progress: progress)
+                    }
                     if viewModel.hasNoTransactions {
                         EmptyStateView(
                             icon: "plus.circle",

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardView.swift
@@ -9,7 +9,9 @@ import SwiftData
 struct DashboardView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(DashboardViewModel.self) private var viewModel
+    @Environment(TransactionListViewModel.self) private var transactionListViewModel
     @Binding var showingAddItemView: Bool
+    @Binding var selectedTab: TabItem
 
     var body: some View {
         NavigationStack {
@@ -22,8 +24,21 @@ struct DashboardView: View {
                             viewModel.dismissAnomaly()
                         }
                     }
-                    ForEach(viewModel.nearLimitBudgets) { progress in
-                        BudgetProgressBarView(progress: progress)
+                    if !viewModel.nearLimitBudgets.isEmpty {
+                        Text("NEAR BUDGET LIMIT")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.textDim)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        GlassEffectContainer(spacing: 20) {
+                            VStack(spacing: 20) {
+                                ForEach(viewModel.nearLimitBudgets) { progress in
+                                    BudgetProgressBarView(progress: progress) {
+                                        transactionListViewModel.selectedCategory = progress.categoryName
+                                        selectedTab = .activity
+                                    }
+                                }
+                            }
+                        }
                     }
                     if viewModel.hasNoTransactions {
                         EmptyStateView(
@@ -57,8 +72,9 @@ struct DashboardView: View {
     SampleData.populateModelContext(container.mainContext)
     let repo = TransactionActor.make(container)
     let dashVM = DashboardViewModel(repo: repo)
-    return DashboardView(showingAddItemView: .constant(false))
+    return DashboardView(showingAddItemView: .constant(false), selectedTab: .constant(.home))
         .environment(dashVM)
+        .environment(TransactionListViewModel(repo: repo))
         .environment(ProfileViewModel())
         .modelContainer(container)
         .preferredColorScheme(.dark)

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Dashboard/DashboardViewModel.swift
@@ -20,10 +20,12 @@ final class DashboardViewModel {
     var recentTransactions: [TransactionSnapshot] = []
     var loadError: String? = nil
     var anomalyCallout: AnomalyCallout? = nil
+    var nearLimitBudgets: [BudgetProgress] = []
 
     private let repo: any ITransactionRepository
     private let currencyService = CurrencyService()
     private var isLoaded = false
+    private var categories: [CategorySnapshot] = []
 
     init(repo: any ITransactionRepository) {
         self.repo = repo
@@ -50,7 +52,10 @@ final class DashboardViewModel {
 
     private func fetchAndCompute() async {
         do {
-            transactions = try await repo.fetchAll()
+            async let txs = repo.fetchAll()
+            async let cats = repo.fetchCategories()
+            transactions = try await txs
+            categories = try await cats
             await calculateMetrics()
         } catch {
             loadError = error.localizedDescription
@@ -79,6 +84,7 @@ final class DashboardViewModel {
             payCycleStartDay: payCycleStartDay,
             dismissedKey: UserDefaults.standard.string(forKey: Self.dismissedAnomalyDefaultsKey)
         )
+        nearLimitBudgets = Self.computeNearLimitBudgets(transactions, categories, payCycleStartDay: payCycleStartDay)
     }
 
     nonisolated private static func computeMetrics(
@@ -112,6 +118,17 @@ final class DashboardViewModel {
     }
 
     private static let dismissedAnomalyDefaultsKey = "dismissedAnomalyCalloutKey"
+
+    nonisolated static func computeNearLimitBudgets(
+        _ transactions: [TransactionSnapshot],
+        _ categories: [CategorySnapshot],
+        payCycleStartDay: Int
+    ) -> [BudgetProgress] {
+        let progress = BudgetProgressService.computeProgress(
+            categories: categories, transactions: transactions, payCycleStartDay: payCycleStartDay
+        )
+        return BudgetProgressService.nearLimit(progress)
+    }
 
     nonisolated static func computeAnomalyCallout(
         _ transactions: [TransactionSnapshot],

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/GoalDetailSheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/GoalDetailSheet.swift
@@ -180,7 +180,7 @@ struct GoalDetailSheet: View {
                     .glassEffect(.regular)
 
                     Button("Confirm") {
-                        if let amount = Decimal(string: fundAmountText), amount > 0 {
+                        if let amount = AmountParser.parse(fundAmountText, requirePositive: true) {
                             viewModel.addFunds(amount: amount, to: goal)
                         }
                         fundAmountText = ""
@@ -191,7 +191,7 @@ struct GoalDetailSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                     .glassEffect(.regular.tint(goalColor).interactive())
-                    .disabled(Decimal(string: fundAmountText) == nil || fundAmountText.isEmpty)
+                    .disabled(AmountParser.parse(fundAmountText, requirePositive: true) == nil)
                 }
             }
         }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
@@ -33,7 +33,7 @@ struct MainTabView: View {
         ZStack(alignment: .bottomTrailing) {
             TabView(selection: $selectedTab) {
                 Tab("Home", systemImage: selectedTab == .home ? "house.fill" : "house", value: .home) {
-                    DashboardView(showingAddItemView: $showingAddItemView)
+                    DashboardView(showingAddItemView: $showingAddItemView, selectedTab: $selectedTab)
                         .payCycleAware { dashboardViewModel.load() }
                 }
                 Tab("Activity", systemImage: selectedTab == .activity ? "list.bullet.rectangle.fill" : "list.bullet.rectangle", value: .activity) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileBudgetsSection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileBudgetsSection.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct ProfileBudgetsSection: View {
+    @Binding var selectedDetent: PresentationDetent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("BUDGETS")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.textDim)
+                .padding(.horizontal, 4)
+            NavigationLink {
+                BudgetsView()
+            } label: {
+                Text("Manage Budgets")
+                    .foregroundStyle(.textPrimary)
+            }
+            .buttonStyle(.plain)
+            .simultaneousGesture(TapGesture().onEnded {
+                selectedDetent = .large
+            })
+        }
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileBudgetsSection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileBudgetsSection.swift
@@ -1,7 +1,14 @@
 import SwiftUI
+import SwiftData
 
 struct ProfileBudgetsSection: View {
     @Binding var selectedDetent: PresentationDetent
+    @Binding var route: ProfileRoute?
+    @Query(sort: \CategoryModel.name) private var categories: [CategoryModel]
+
+    private var budgetedCount: Int {
+        categories.filter { $0.transactionType == .expense && ($0.monthlyBudget ?? 0) > 0 }.count
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -9,16 +16,25 @@ struct ProfileBudgetsSection: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.textDim)
                 .padding(.horizontal, 4)
-            NavigationLink {
-                BudgetsView()
+            Button {
+                selectedDetent = .large
+                route = .budgets
             } label: {
-                Text("Manage Budgets")
-                    .foregroundStyle(.textPrimary)
+                HStack {
+                    Text("Manage Budgets")
+                        .foregroundStyle(.textPrimary)
+                    Spacer()
+                    if budgetedCount > 0 {
+                        Text("\(budgetedCount) set")
+                            .foregroundStyle(.textDim)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.textDim)
+                }
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .simultaneousGesture(TapGesture().onEnded {
-                selectedDetent = .large
-            })
         }
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileCategoriesSection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileCategoriesSection.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ProfileCategoriesSection: View {
     @Binding var selectedDetent: PresentationDetent
+    @Binding var route: ProfileRoute?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -9,16 +10,21 @@ struct ProfileCategoriesSection: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.textDim)
                 .padding(.horizontal, 4)
-            NavigationLink {
-                CategorySettingsView()
+            Button {
+                selectedDetent = .large
+                route = .categories
             } label: {
-                Text("Manage Categories")
-                    .foregroundStyle(.textPrimary)
+                HStack {
+                    Text("Manage Categories")
+                        .foregroundStyle(.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.textDim)
+                }
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .simultaneousGesture(TapGesture().onEnded {
-                selectedDetent = .large
-            })
         }
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileSecuritySection.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Components/ProfileSecuritySection.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ProfileSecuritySection: View {
     @Bindable var viewModel: ProfileViewModel
     @Binding var selectedDetent: PresentationDetent
+    @Binding var route: ProfileRoute?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -11,21 +12,21 @@ struct ProfileSecuritySection: View {
                 .foregroundStyle(.textDim)
                 .padding(.horizontal, 4)
             VStack {
-                NavigationLink {
-                    PINSetupView(
-                        viewModel: PINSetupViewModel(
-                            pinService: PINService(),
-                            isChangeMode: true
-                        )
-                    )
+                Button {
+                    selectedDetent = .large
+                    route = .changePIN
                 } label: {
-                    Text("Change PIN")
-                        .foregroundStyle(.textPrimary)
+                    HStack {
+                        Text("Change PIN")
+                            .foregroundStyle(.textPrimary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.textDim)
+                    }
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .simultaneousGesture(TapGesture().onEnded {
-                    selectedDetent = .large
-                })
 
                 if viewModel.isBiometricsAvailable {
                     Divider()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -3,6 +3,10 @@ import UniformTypeIdentifiers
 import SwiftData
 import CoreTransferable
 
+enum ProfileRoute: Hashable {
+    case categories, budgets, changePIN
+}
+
 struct ProfileView: View {
     @Bindable var viewModel: ProfileViewModel
     @Binding var selectedDetent: PresentationDetent
@@ -15,6 +19,7 @@ struct ProfileView: View {
     @State private var showingPINConfirmation = false
     @State private var showingDeleteSuccess = false
     @State private var deleteErrorMessage: String?
+    @State private var route: ProfileRoute?
     private let pinService = PINService()
 
     var body: some View {
@@ -39,11 +44,11 @@ struct ProfileView: View {
                     }
                     .appFormSectionBackground()
                     Section {
-                        ProfileCategoriesSection(selectedDetent: $selectedDetent)
+                        ProfileCategoriesSection(selectedDetent: $selectedDetent, route: $route)
                     }
                     .appFormSectionBackground()
                     Section {
-                        ProfileBudgetsSection(selectedDetent: $selectedDetent)
+                        ProfileBudgetsSection(selectedDetent: $selectedDetent, route: $route)
                     }
                     .appFormSectionBackground()
                     Section {
@@ -94,11 +99,21 @@ struct ProfileView: View {
                     }
                     .appFormSectionBackground()
                     Section {
-                        ProfileSecuritySection(viewModel: viewModel, selectedDetent: $selectedDetent)
+                        ProfileSecuritySection(viewModel: viewModel, selectedDetent: $selectedDetent, route: $route)
                     }
                     .appFormSectionBackground()
                 }
                 .appFormBackground()
+                .navigationDestination(item: $route) { route in
+                    switch route {
+                    case .categories: CategorySettingsView()
+                    case .budgets: BudgetsView()
+                    case .changePIN:
+                        PINSetupView(
+                            viewModel: PINSetupViewModel(pinService: pinService, isChangeMode: true)
+                        )
+                    }
+                }
             }
             .padding(.top, 24)
             .appBackground()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -43,6 +43,10 @@ struct ProfileView: View {
                     }
                     .appFormSectionBackground()
                     Section {
+                        ProfileBudgetsSection(selectedDetent: $selectedDetent)
+                    }
+                    .appFormSectionBackground()
+                    Section {
                         Button {
                             showingFileImporter = true
                         } label: {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/AmountFilterSheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/AmountFilterSheet.swift
@@ -55,13 +55,12 @@ struct AmountFilterSheet: View {
         }
     }
 
-    // ponytail: comma→period for European locale decimal input
     private var parsedMin: Decimal? {
-        Decimal(string: minText.replacingOccurrences(of: ",", with: "."))
+        AmountParser.parse(minText)
     }
 
     private var parsedMax: Decimal? {
-        Decimal(string: maxText.replacingOccurrences(of: ",", with: "."))
+        AmountParser.parse(maxText)
     }
 
     private var isInvalidRange: Bool {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Models/TransactionCategory.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Models/TransactionCategory.swift
@@ -71,7 +71,7 @@ struct TransactionCategory: Identifiable, Hashable, Codable {
         TransactionCategory(systemImage: "graduationcap", label: "Education"),
         TransactionCategory(systemImage: "pawprint", label: "Pets"),
         TransactionCategory(systemImage: "creditcard", label: "Banking Fees"),
-        TransactionCategory(systemImage: "questionmark", label: "Other")
+        TransactionCategory(systemImage: "ellipsis.circle", label: "Other")
     ]
     
     static let defaultCategories: [TransactionCategory] = incomeCategories + expenseCategories

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AmountParser.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AmountParser.swift
@@ -1,0 +1,28 @@
+//  AmountParser.swift
+//  PersonalFinanceTraker
+
+import Foundation
+
+/// Shared parse/format for user-entered Decimal amounts across the app's
+/// money-input screens (Budgets, Amount filter, Goal funds, Credit card).
+/// Not for `CurrencyAmountField` (Double-based) or `AddGoalSheet` (comma =
+/// thousands separator there, not decimal) — both have different semantics.
+enum AmountParser {
+    /// European decimal-pad convention: comma is the decimal separator.
+    /// Returns nil for empty/unparseable input; when requirePositive, also
+    /// nil for values <= 0.
+    static func parse(_ text: String, requirePositive: Bool = false) -> Decimal? {
+        let normalized = text
+            .trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: ",", with: ".")
+        guard let value = Decimal(string: normalized) else { return nil }
+        if requirePositive && value <= 0 { return nil }
+        return value
+    }
+
+    /// Currency display matching the convention already used by Budgets
+    /// (`.formatted(.currency(code:))`).
+    static func format(_ value: Decimal, currencyCode: String = "EUR") -> String {
+        value.formatted(.currency(code: currencyCode))
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AppToolbarModifier.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/AppToolbarModifier.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct AppToolbarModifier: ViewModifier {
     @Environment(ProfileViewModel.self) private var profileViewModel: ProfileViewModel
     @Environment(TransactionListViewModel.self) private var transactionViewModel: TransactionListViewModel
+    @Environment(DataChangedSignal.self) private var dataChanged: DataChangedSignal
     @Binding var showingAddItemView: Bool
     @State private var showingProfile = false
     @State private var selectedDetent: PresentationDetent = .large
@@ -35,6 +36,7 @@ struct AppToolbarModifier: ViewModifier {
             }
             .sheet(isPresented: $showingProfile) {
                 ProfileView(viewModel: profileViewModel, selectedDetent: $selectedDetent)
+                    .environment(dataChanged)
                     .presentationDetents([.medium, .large], selection: $selectedDetent)
                     .presentationBackground { AppBackground() }
             }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BudgetProgressService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BudgetProgressService.swift
@@ -1,0 +1,60 @@
+//  BudgetProgressService.swift
+//  PersonalFinanceTraker
+
+import Foundation
+import SwiftData
+
+struct BudgetProgress: Identifiable, Equatable, Sendable {
+    let id: PersistentIdentifier
+    let categoryName: String
+    let systemImage: String
+    let colorToken: String
+    let budget: Decimal
+    let spent: Decimal
+
+    var percent: Double {
+        guard budget > 0 else { return 0 }
+        return Double(truncating: (spent / budget) as NSDecimalNumber)
+    }
+
+    var isOverBudget: Bool { spent > budget }
+}
+
+enum BudgetProgressService {
+    static func computeProgress(
+        categories: [CategorySnapshot],
+        transactions: [TransactionSnapshot],
+        payCycleStartDay: Int,
+        calendar: Calendar = .current
+    ) -> [BudgetProgress] {
+        let budgeted = categories.filter {
+            $0.transactionType == .expense && ($0.monthlyBudget ?? 0) > 0
+        }
+        guard !budgeted.isEmpty else { return [] }
+
+        let (cycleStart, cycleEnd) = PayCycleService.currentFinancialMonth(
+            startDay: payCycleStartDay, calendar: calendar
+        )
+
+        var spentByCategory: [String: Decimal] = [:]
+        for tx in transactions where tx.amount < 0 {
+            guard tx.timestamp >= cycleStart && tx.timestamp <= cycleEnd else { continue }
+            spentByCategory[tx.category, default: 0] += abs(tx.amount)
+        }
+
+        return budgeted.map { category in
+            BudgetProgress(
+                id: category.persistentId,
+                categoryName: category.name,
+                systemImage: category.systemImage,
+                colorToken: category.colorToken,
+                budget: category.monthlyBudget ?? 0,
+                spent: spentByCategory[category.name] ?? 0
+            )
+        }
+    }
+
+    static func nearLimit(_ progress: [BudgetProgress], threshold: Double = 0.8) -> [BudgetProgress] {
+        progress.filter { $0.percent >= threshold }.sorted { $0.percent > $1.percent }
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BudgetProgressService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BudgetProgressService.swift
@@ -18,6 +18,7 @@ struct BudgetProgress: Identifiable, Equatable, Sendable {
     }
 
     var isOverBudget: Bool { spent > budget }
+    var isNearLimit: Bool { !isOverBudget && percent >= 0.8 }
 }
 
 enum BudgetProgressService {

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Dashboard/DashboardViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Dashboard/DashboardViewModelTests.swift
@@ -172,4 +172,44 @@ struct DashboardViewModelTests {
         )
         #expect(callout == nil)
     }
+
+    @Test func nearLimitBudgetsIncludesCategoryOverThreshold() async {
+        let (cycleStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let repo = MockTransactionRepository()
+        repo.stubbedCategories = [CategorySnapshot.test(name: "Groceries", monthlyBudget: 100)]
+        repo.stubbedTransactions = [
+            TransactionSnapshot.test(timestamp: cycleStart, amount: -90, category: "Groceries")
+        ]
+        let vm = DashboardViewModel(repo: repo)
+        vm.payCycleStartDay = { 1 }
+        vm.load()
+        await vm.loadTask?.value
+
+        #expect(vm.nearLimitBudgets.count == 1)
+        #expect(vm.nearLimitBudgets.first?.categoryName == "Groceries")
+    }
+
+    @Test func nearLimitBudgetsExcludesCategoryUnderThreshold() async {
+        let (cycleStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let repo = MockTransactionRepository()
+        repo.stubbedCategories = [CategorySnapshot.test(name: "Groceries", monthlyBudget: 100)]
+        repo.stubbedTransactions = [
+            TransactionSnapshot.test(timestamp: cycleStart, amount: -10, category: "Groceries")
+        ]
+        let vm = DashboardViewModel(repo: repo)
+        vm.payCycleStartDay = { 1 }
+        vm.load()
+        await vm.loadTask?.value
+
+        #expect(vm.nearLimitBudgets.isEmpty)
+    }
+
+    @Test func computeNearLimitBudgetsIsStaticallyTestable() {
+        let category = CategorySnapshot.test(name: "Fun", monthlyBudget: 50)
+        let tx = TransactionSnapshot.test(timestamp: .now, amount: -45, category: "Fun")
+
+        let result = DashboardViewModel.computeNearLimitBudgets([tx], [category], payCycleStartDay: 1)
+
+        #expect(result.count == 1)
+    }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/AmountParserTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/AmountParserTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import PersonalFinanceTraker
+import Foundation
+
+@Suite
+struct AmountParserTests {
+
+    @Test func parsesPlainDigits() {
+        #expect(AmountParser.parse("350") == 350)
+    }
+
+    @Test func normalizesCommaToPeriod() {
+        #expect(AmountParser.parse("5,50") == 5.5)
+    }
+
+    @Test func trimsWhitespace() {
+        #expect(AmountParser.parse("  350  ") == 350)
+    }
+
+    @Test func emptyStringReturnsNil() {
+        #expect(AmountParser.parse("") == nil)
+    }
+
+    @Test func garbageReturnsNil() {
+        #expect(AmountParser.parse("abc") == nil)
+    }
+
+    @Test func permissiveModeAcceptsZero() {
+        #expect(AmountParser.parse("0") == 0)
+    }
+
+    @Test func permissiveModeAcceptsNegative() {
+        #expect(AmountParser.parse("-5") == -5)
+    }
+
+    @Test func requirePositiveRejectsZero() {
+        #expect(AmountParser.parse("0", requirePositive: true) == nil)
+    }
+
+    @Test func requirePositiveRejectsNegative() {
+        #expect(AmountParser.parse("-5", requirePositive: true) == nil)
+    }
+
+    @Test func requirePositiveAcceptsPositive() {
+        #expect(AmountParser.parse("5", requirePositive: true) == 5)
+    }
+
+    @Test func formatsAsEURCurrency() {
+        #expect(AmountParser.format(111.10, currencyCode: "EUR") == Decimal(111.10).formatted(.currency(code: "EUR")))
+    }
+
+    @Test func formatDefaultsToEUR() {
+        #expect(AmountParser.format(50) == Decimal(50).formatted(.currency(code: "EUR")))
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BudgetProgressServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BudgetProgressServiceTests.swift
@@ -1,0 +1,95 @@
+import Testing
+@testable import PersonalFinanceTraker
+import Foundation
+
+@Suite
+struct BudgetProgressServiceTests {
+
+    @Test func includesCategoryWithBudgetSet() {
+        let category = CategorySnapshot.test(name: "Groceries", monthlyBudget: 300)
+        let (cycleStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let tx = TransactionSnapshot.test(timestamp: cycleStart, amount: -50, category: "Groceries")
+
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [tx], payCycleStartDay: 1
+        )
+
+        #expect(result.count == 1)
+        #expect(result.first?.categoryName == "Groceries")
+        #expect(result.first?.budget == 300)
+        #expect(result.first?.spent == 50)
+    }
+
+    @Test func excludesCategoryWithoutBudget() {
+        let category = CategorySnapshot.test(name: "Fun", monthlyBudget: nil)
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [], payCycleStartDay: 1
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func excludesCategoryWithZeroBudget() {
+        let category = CategorySnapshot.test(name: "Fun", monthlyBudget: 0)
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [], payCycleStartDay: 1
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func excludesIncomeCategories() {
+        let category = CategorySnapshot.test(name: "Salary", type: .income, monthlyBudget: 1000)
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [], payCycleStartDay: 1
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func excludesTransactionOutsideCurrentCycle() {
+        let category = CategorySnapshot.test(name: "Groceries", monthlyBudget: 300)
+        let (cycleStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let before = Calendar.current.date(byAdding: .day, value: -1, to: cycleStart)!
+        let tx = TransactionSnapshot.test(timestamp: before, amount: -50, category: "Groceries")
+
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [tx], payCycleStartDay: 1
+        )
+        #expect(result.first?.spent == 0)
+    }
+
+    @Test func excludesIncomeTransactionsFromSpent() {
+        let category = CategorySnapshot.test(name: "Groceries", monthlyBudget: 300)
+        let (cycleStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let tx = TransactionSnapshot.test(timestamp: cycleStart, amount: 50, category: "Groceries")
+
+        let result = BudgetProgressService.computeProgress(
+            categories: [category], transactions: [tx], payCycleStartDay: 1
+        )
+        #expect(result.first?.spent == 0)
+    }
+
+    @Test func percentAndOverBudgetComputedCorrectly() {
+        let progress = BudgetProgress(
+            id: CategorySnapshot.test(name: "Groceries", monthlyBudget: 200).persistentId,
+            categoryName: "Groceries", systemImage: "cart", colorToken: "categoryGreen",
+            budget: 200, spent: 180
+        )
+        #expect(progress.percent == 0.9)
+        #expect(progress.isOverBudget == false)
+
+        let over = BudgetProgress(
+            id: progress.id, categoryName: "Groceries", systemImage: "cart", colorToken: "categoryGreen",
+            budget: 200, spent: 250
+        )
+        #expect(over.isOverBudget == true)
+    }
+
+    @Test func nearLimitFiltersAndSortsDescending() {
+        let low = BudgetProgress(id: CategorySnapshot.test(name: "A", monthlyBudget: 100).persistentId, categoryName: "A", systemImage: "cart", colorToken: "categoryGreen", budget: 100, spent: 10)
+        let high = BudgetProgress(id: CategorySnapshot.test(name: "B", monthlyBudget: 100).persistentId, categoryName: "B", systemImage: "cart", colorToken: "categoryGreen", budget: 100, spent: 95)
+        let mid = BudgetProgress(id: CategorySnapshot.test(name: "C", monthlyBudget: 100).persistentId, categoryName: "C", systemImage: "cart", colorToken: "categoryGreen", budget: 100, spent: 85)
+
+        let result = BudgetProgressService.nearLimit([low, high, mid], threshold: 0.8)
+
+        #expect(result.map(\.categoryName) == ["B", "C"])
+    }
+}

--- a/docs/product-analysis-2026-07-23.md
+++ b/docs/product-analysis-2026-07-23.md
@@ -1,0 +1,150 @@
+# Product & Market Analysis — Personal Finance Tracker (iOS)
+
+*Date: 2026-07-23 (updated 2026-07-29: "Now" tier shipped, see note below)*
+
+> **Update 2026-07-29:** All five "Now" tier items below have shipped: App Intent quick-add (Siri/Shortcuts, with category/type prompting and negative-amount forgiveness), daily logging reminder, persisted import mappings per file signature, Dashboard anomaly callout, `CreditScoreCard` deleted (not wired — was dead UI), and the README updated. The rest of this document (Next/Later tiers, gap analysis, competitive advantages) is unchanged and still reflects the current state.
+
+## Executive Summary
+
+**What it is:** A privacy-first, manual-entry personal finance tracker for iOS 26+, built with SwiftUI + SwiftData, MVVM, all data local to the device. Five tabs: Dashboard, Activity, Insights ("Compass"), Credit, Profile. EUR-only, single implicit account, expenses stored as negative Decimals.
+
+**Target user:** A single, privacy-conscious individual (currently, essentially the developer) who manually logs or bulk-imports transactions from bank exports (CSV/XLSX), and wants analysis on top — not bank-linking automation.
+
+**Maturity: solid mid-stage.** The analytics layer is unusually deep for an indie tracker (health score with historical snapshots, spending forecast with caching, anomaly detection, habit insights, goal pockets with a real `transfer` transaction type, pay-cycle-aware periods everywhere). Architecture is clean: repository protocol + snapshot value types + `TransactionActor` for concurrency, no import cycles, 200+ Swift Testing tests, a design-token system. What's *thin* is the platform layer: **empty entitlements, zero widgets, no sync, no watch app**. As of 2026-07-29, the App Intent quick-add and daily logging notification have closed the biggest logging-speed gaps; the app is still largely a well-built island otherwise.
+
+**The strategic read:** Market research shows the post-Mint audience explicitly prioritizes (1) speed of logging, (2) privacy/no bank linking, (3) not being hostage to a subscription cloud service ([Vento's Reddit analysis](https://vento.money/blog/best-budget-expense-tracker-what-reddit-actually-says/), [Finny](https://getfinny.app/blog/best-budget-apps-reddit-recommends-2026)). This app is *architecturally aligned* with all three, and the Siri/Shortcuts quick-add now gives it a real out-of-app logging path — but it still lacks the two features every manual-entry competitor ships: **budgets** and **recurring transactions**.
+
+---
+
+## Current Feature Inventory
+
+| Area | Shipped |
+|---|---|
+| Dashboard | Balance card, pay-cycle income/expense summary, greeting header, recent transactions |
+| Activity | Grouped transaction history, live text search, type/date/amount filter chips, swipe-to-delete with undo banner |
+| Insights ("Compass") | Health score v2 (arc gauge, component breakdown, historical snapshots, tips), spending forecast (sliding window + `DailyForecastCache`), goal pockets (with `transfer` type + `goalId`), habit observations, category trends, hero insight card, timeline anomaly detection, category pie/breakdown charts with EUR legend |
+| Credit | Credit card management, utilization card, credit score card |
+| Transactions | Add/edit sheet with category, amount (custom currency field), date, notes |
+| Categories | Custom categories with icon grid + color token pickers, per-type (income/expense) |
+| Import/Export | CSV and XLSX import with column-mapping and category-mapping wizard; CSV/XLSX export |
+| Security | PIN (CryptoKit-hashed) + Face ID/Touch ID lock, PIN-confirmed "Delete All Data" wipe |
+| Settings | Pay-cycle start day (drives all period math), personal info, currency display section |
+
+## Hidden / Unfinished Features (found in code, not surfaced or incomplete)
+
+1. ~~README "Work in Progress" is stale~~ — **done 2026-07-29**, README now reflects search/biometrics as shipped. iCloud sync and budgeting remain genuinely unbuilt.
+2. **Multi-currency scaffolding exists but is dormant** — `CurrencyService` and `ProfileCurrencySection` exist, yet EUR is hardcoded throughout. Half the plumbing for currency selection is already there.
+3. ~~`CreditScoreCard` renders a score with no real data source~~ — **deleted 2026-07-29** along with its manual score state; was dead UI with no data source.
+4. **`TransactionType.transfer`** was added for goal pockets but isn't exposed as a general user-facing concept (e.g., transfers between future "accounts").
+5. **Empty entitlements file** — no App Groups, Keychain sharing, or CloudKit container. Every platform-extension feature (widget, watch, sync) needs this bootstrapped first.
+
+---
+
+## Missing Features (Gap Analysis vs. Market)
+
+Competitors examined: [MoneyCoach](https://moneycoach.ai/features) (closest analog: manual-first, privacy-first, EU-friendly), [Cashew](https://apps.apple.com/us/app/cashew-expense-budget-tracker/id6463662930) (free manual tracker), [Copilot](https://www.copilot.money/), [YNAB / Monarch](https://walletgrower.com/compare/ynab-vs-monarch-vs-copilot) (subscription bank-linkers — indirect competitors, since this app deliberately doesn't bank-link).
+
+| Feature | User value | Why competitors have it | Complexity | Priority |
+|---|---|---|---|---|
+| **Budgets / spending limits per category** | The #1 reason people open a finance app; turns passive tracking into behavior change | Table stakes — every single competitor (MoneyCoach, Cashew, YNAB, Copilot) has it | **Medium** — category infra, pay-cycle periods, and `SpendingInsightService` already provide 80% of the math | **P0** (already in the README) |
+| **Recurring transactions / subscription tracking** | Rent, salary, subscriptions are most of a ledger; manual re-entry is the top abandonment driver | Cashew ships it with reminders; MoneyCoach ships it; users on Reddit cite logging friction as reason #1 for quitting | **Medium** — a `RecurrenceRule` on `TransactionModel` + materialization on app launch (no background task needed) | **P0** |
+| **Home-screen widget (balance / safe-to-spend)** | Glanceability = retention; interactive widgets drive [12–18% re-entry lift](https://www.forasoft.com/blog/article/9-tips-to-make-ios-app-cooler-86) | MoneyCoach ships budget widgets; Cashews ships a "Can I afford it?" widget | **Medium** — WidgetKit + App Group to share the SwiftData store | **P0** |
+| **Quick add via App Intents / Shortcuts / Siri** | "Speed of logging" is the market's most-cited want | MoneyCoach ships Quick Entry + Shortcuts; [App Intents feeds Siri, Spotlight, widgets, Apple Intelligence](https://blakecrosley.com/blog/app-intents-2-ios-26-additions) — one intent, many surfaces | **Low–Medium** | **P0** |
+| **iCloud sync (SwiftData + CloudKit)** | Device loss = total data loss today; the Mint shutdown made data durability a top-3 question in recommendation threads | All competitors sync; for a local-first app, *private* CloudKit sync preserves the privacy story | **Medium** — SwiftData has native CloudKit support; the migration policy (no App Store, reinstall OK) removes the usual schema-migration pain | **P1** |
+| **Multi-currency** | EUR hardcoding blocks any second user and travel use | Standard everywhere | **Medium** — `CurrencyService` exists; the work is display-layer sweep, not architecture | **P1** |
+| **Multiple accounts** (checking/cash/savings) | Real people have >1 pot of money; credit cards already prove the pattern | Universal | **Medium–High** — `CreditCardRepository` is the template; `transfer` type already exists | **P1** |
+| **Spending notifications / bill reminders** | Habit formation and "log it before you forget" | MoneyCoach, Cashew both remind | **Low** once recurring transactions exist | **P1** |
+| **Receipt photo attachment** | Manual-entry users often want proof-of-purchase | Common in manual trackers | **Low** (SwiftData external storage blob) | **P2** |
+| **Apple Watch quick-log** | Fastest possible logging surface | MoneyCoach ships it | **High** | **P2** |
+
+---
+
+## Quick Wins (low effort, high impact) — ALL SHIPPED 2026-07-29
+
+1. ~~App Intents "Add Transaction" + Shortcuts~~ — **shipped**: `AddTransactionIntent` reuses the add-transaction logic, prompts for category/type, forgives negative amounts. Siri/Spotlight/Shortcuts entry now exists.
+2. ~~Bill/log reminders via local notifications~~ — **shipped**: daily logging reminder, skip-if-already-logged, configurable in Profile settings.
+3. ~~Remember import mappings~~ — **shipped**: column and category mappings persist per file signature (headers hash), so repeat monthly imports are one tap.
+4. ~~Update README / surface finished work~~ — **shipped**: README now lists search and biometrics as done.
+5. ~~Anomaly alerts surfaced on Dashboard~~ — **shipped**: dismissible Dashboard callout built on `TimelineAnomalyService`.
+
+(`CreditScoreCard`, previously flagged as dead placeholder UI, was deleted rather than wired — no real data source existed to back it.)
+
+## Medium Projects
+
+1. **Budgets per category, pay-cycle-native** — the pay-cycle engine is the differentiator here: budgets that reset on *your payday*, not the 1st of the month, is something even YNAB approximates awkwardly. Reuses `PayCycleService`, `CategoryModel`, `SpendingInsightService`, filter chips UI patterns.
+2. **Recurring transactions** — `RecurrenceRule` on the model, materialize-on-launch, edit-series vs. edit-instance. Unlocks reminders, subscription insights ("you spend €47/mo on subscriptions"), and better forecasts (`SpendingForecastService` gets known-future cash flows instead of pure extrapolation).
+3. **Widgets: balance + safe-to-spend + budget rings** — requires the App Group/entitlements bootstrap; after that, `DashboardViewModel`'s snapshot pattern maps cleanly onto timeline entries.
+4. **iCloud private sync** — flip SwiftData to a CloudKit container. Given the no-migration policy, this is a rare cheap window to do it *before* the schema calcifies further. Also the honest answer to "what if I lose my phone" for a local-only app.
+5. **Multi-currency** — finish what `CurrencyService` started; store currency per transaction, display in home currency.
+
+## Major Initiatives
+
+1. **Accounts model** — promote the implicit single account to first-class `AccountModel` (checking, cash, savings, linking existing credit cards), with `transfer` between them. This is the schema change that unlocks net-worth tracking and makes the app a Monarch-class ledger. Do it *before* iCloud sync locks the schema, or accept a reinstall (policy allows it).
+2. **Apple Watch app** — 3-tap logging (category grid → amount → done). Highest-leverage logging surface, but a whole new target.
+3. **On-device AI assist (see below)** — natural-language entry and import auto-categorization via Apple's on-device Foundation Models.
+
+## Technical Opportunities (existing code to leverage)
+
+- **Snapshot architecture → widgets & watch for free-ish**: `TransactionSnapshot`/`HealthScoreSnapshot`/`DailyForecastCacheData` are `Sendable` value types already decoupled from SwiftData — exactly what widget timelines and watch connectivity need.
+- **`ITransactionRepository` protocol** means every new surface (intent, widget, watch) can be tested against `MockTransactionRepository` — the test infra is a genuine asset here.
+- **`FinancialHealthService` + snapshots** → health-score *history chart* ("your score over 6 months") is mostly a query + chart away.
+- **`transfer` type + `goalId`** → generalizes to account transfers with minimal model change.
+- **`CreditScoreCard` placeholder** → either wire it to something real (utilization-derived score) or delete it; today it's dead UI.
+- **`DataWipeService` + PIN confirmation** → reusable pattern for "export then wipe" data-portability flow, a strong privacy-story feature.
+
+## AI Opportunities (only where it solves a real problem)
+
+1. **Import auto-categorization** — the *real* pain in the current workflow: after CSV/XLSX import, mapping dozens of merchant strings to categories by hand. On-device [Foundation Models](https://www.ksolves.com/blog/mobile-app-development/ios-26-features) (iOS 26, no server, fits the privacy story) can classify "CARREFOUR MARKET 1234" → Groceries. Fallback: a learned string-match dictionary (no AI at all) gets 70% of the value — ship that first.
+2. **Natural-language quick add** — "coffee 3.50" → parsed transaction. Pairs with the App Intent; the on-device model does entity extraction. Skip a chatbot; this is a parser, not a conversation.
+3. **Narrative insights** — narrative summaries already exist via `SpendingInsightService` with deterministic code. Keep it deterministic; AI adds cost and nondeterminism for prose already produced. *Recommend against.*
+
+## Competitive Advantages (innovation candidates competitors don't have)
+
+1. **Pay-cycle-native "Safe to Spend until payday"** — combine `PayCycleService` + forecast + recurring commitments into one number on Dashboard/widget/Live Activity. Cashews grades affordability A–F; nobody does it *anchored to your actual payday*. This is the flagship differentiator — the whole app already thinks in pay cycles.
+2. **End-of-pay-cycle Live Activity** — last 3 days before payday, a [Live Activity](https://swiftcrafted.dev/article/live-activities-dynamic-island-ios-26-swiftui-activitykit-guide) showing remaining safe-to-spend. Novel, on-trend, and only sensible for a pay-cycle-aware app.
+3. **Privacy-first positioning made explicit** — "your data never leaves your device (optionally your private iCloud)" + export-anytime + PIN-wipe. The market is *actively searching* for this post-Mint; competitors can't credibly claim it because their business model is bank aggregation.
+4. **Bank-statement import intelligence** — per-bank import profiles (delimiter, date format, column mapping, merchant→category memory) that make monthly statement import a one-tap ritual. Bank-linking apps can't compete here; other manual apps do naive CSV import.
+5. **Health score with receipts** — score history is already snapshotted; show *why* it moved ("score dropped 4 pts: utilization up"). Credit-score apps do this for credit; nobody does it for holistic finance health.
+6. **Anomaly-driven "unusual spend" review** — a weekly digest of `TimelineAnomalyService` findings framed as a 60-second review ritual, not a feed.
+
+---
+
+## Prioritized Roadmap
+
+### Now — High Impact / Low Effort — ALL SHIPPED 2026-07-29
+1. ~~App Intent quick-add (+ Shortcuts/Siri/Spotlight for free)~~ ✅
+2. ~~Daily logging reminder notification~~ ✅
+3. ~~Persist import column/category mappings per bank file signature~~ ✅
+4. ~~Surface anomalies on Dashboard; wire or delete `CreditScoreCard`; update README~~ ✅ (deleted `CreditScoreCard`)
+
+### Next — High Impact / Medium Effort
+5. **Budgets** (pay-cycle-native — the differentiator framing)
+6. **Recurring transactions** (then bill reminders, then better forecasts)
+7. Entitlements bootstrap + **balance/safe-to-spend widget**
+8. **iCloud sync** — do this while the no-migration policy still holds
+9. "Safe to Spend until payday" as the Dashboard hero number
+
+### Later — Large Investments
+10. Accounts model + net worth (schema change: sequence before/with sync)
+11. Multi-currency completion
+12. On-device AI import categorization (string-match dictionary first)
+13. Apple Watch quick-log; payday Live Activity
+
+**Sequencing note:** items 10 (accounts) and 8 (sync) interact — schema changes after CloudKit adoption get harder even with the reinstall policy, so decide the account model shape before turning on sync.
+
+---
+
+## Sources
+
+- [Vento — what Reddit actually recommends](https://vento.money/blog/best-budget-expense-tracker-what-reddit-actually-says/)
+- [Finny — Reddit budget app picks 2026](https://getfinny.app/blog/best-budget-apps-reddit-recommends-2026)
+- [WalletGrower — YNAB vs Monarch vs Copilot](https://walletgrower.com/compare/ynab-vs-monarch-vs-copilot)
+- [Techno-Pulse — AI finance tools 2026](https://www.techno-pulse.com/2026/04/best-ai-personal-finance-tools-in-2026.html)
+- [MoneyCoach features](https://moneycoach.ai/features)
+- [Cashew on the App Store](https://apps.apple.com/us/app/cashew-expense-budget-tracker/id6463662930)
+- [Cashews — Can I afford it?](https://cashews.finance/)
+- [Copilot Money](https://www.copilot.money/)
+- [Forasoft — native iOS features 2026](https://www.forasoft.com/blog/article/9-tips-to-make-ios-app-cooler-86)
+- [Swift Crafted — Live Activities iOS 26](https://swiftcrafted.dev/article/live-activities-dynamic-island-ios-26-swiftui-activitykit-guide)
+- [Blake Crosley — App Intents 2.0](https://blakecrosley.com/blog/app-intents-2-ios-26-additions)
+- [Ksolves — iOS 26 developer features](https://www.ksolves.com/blog/mobile-app-development/ios-26-features)

--- a/docs/ux-audit-2026-07-29.md
+++ b/docs/ux-audit-2026-07-29.md
@@ -89,6 +89,39 @@
 - **Learnability: 5/10** — nothing signals the amount field is editable beyond discovering it by tapping; once discovered, the interaction itself is simple.
 - **Overall Experience: 5/10** — the underlying engineering (pay-cycle-aware progress computation, near-limit Dashboard callouts) is strong, but the entry screen's currency formatting gap is the kind of first-impression bug that would make a user distrust the numbers app-wide.
 
+## Addendum — 2026-07-29 (post-fix follow-up)
+
+New screenshot after the Quick Wins + High Impact fixes shipped: the Budgets list now shows formatted currency and a budgeted-row indicator (e.g. "Banking Fees ● 11.111,00 €"), confirming those fixes render correctly. One new issue surfaced by direct user question ("is this monthly, daily, or annual?") that the original three screenshots didn't prompt:
+
+### Budgets screen — no period/unit label
+- **Severity: High — Problem:** Nowhere on the Budgets screen, the row, the section header ("EXPENSE CATEGORIES"), or the screen title ("Budgets") does any text state the period the limit applies to. Code confirms the field is `CategoryModel.monthlyBudget` and `BudgetProgressService` resolves it against `PayCycleService.currentFinancialMonth(startDay:calendar:)` — i.e. a **monthly** limit that resets on the user's pay-cycle day, not the calendar month, not daily, not annual. None of that is surfaced in the UI. **Why it hurts UX:** Nielsen's *match between system and the real world* / *visibility of system status* — for a number that directly represents the user's money, ambiguity about the time period it governs is a trust-breaking gap, not a cosmetic one. It's also worse than a generic "monthly" ambiguity: this app's differentiator is that budgets reset on payday rather than the calendar month, so the *correct* label needs to communicate "per pay cycle," not just "per month," or users will misjudge when their limit resets. **Recommendation:** Add an explicit unit to every place a limit is set or shown:
+  - Section footer/header: "EXPENSE CATEGORIES · resets each pay cycle" or a subtitle under "Budgets" nav title.
+  - Row-level: either a trailing unit suffix ("11.111,00 € / mo") or placeholder copy that states it ("No monthly limit" instead of "No limit").
+  - Cheapest fix: change `BudgetsView`'s section header from "EXPENSE CATEGORIES" to "MONTHLY BUDGET · EXPENSE CATEGORIES", and change `BudgetRow`'s empty-state placeholder from `"No limit"` to `"No monthly limit"` — both are one-line copy changes with no logic risk.
+
+This should be treated as a Quick Win alongside the others — it's copy-only, no layout or logic change required.
+
+## Addendum 2 — 2026-07-30 (Dashboard "near limit" component)
+
+Focused review of `BudgetProgressBarView`, surfaced on the Dashboard via `DashboardViewModel.nearLimitBudgets` (`BudgetProgressService.nearLimit`, threshold ≥80% of the monthly budget) — screenshot shows two cards, "Takeout" (276,00 € / 200,00 €, over budget) and "Groceries" (199,00 € / 200,00 €, 99.5% spent).
+
+### Findings
+
+- **Severity: Critical — Problem:** `BudgetProgressBarView.swift:30-34` fills the card with `.background(RoundedRectangle(cornerRadius: 16).fill(.bg1))` instead of the shared `GlassCard` component (`DesignTokens.swift:124-153`) that every other Dashboard surface uses (Total Balance, Recent Transactions rows). `.bg1` sits close in luminance to the `AppBackground` gradient behind it, so the card reads as text floating on the background rather than a distinct surface — confirmed directly in the screenshot and by the user's own reaction ("the card is not really visible, it confuses with the background"). **Why it hurts UX:** Gestalt *figure-ground* — without a perceptible boundary, the component fails at its most basic job (being noticed) before any of its content can register. **Recommendation:** replace the manual `.background` with `GlassCard { ... }`, matching the rest of the screen (already scoped with the user; pending their go-ahead to implement).
+
+- **Severity: High — Problem:** There is no visual distinction between "comfortably near the limit" and "critically near the limit" — `barColor` (`BudgetProgressBarView.swift:10-12`) is binary: `.negative` (red) only once `spent > budget`, otherwise it's just the category's own assigned color (Takeout's is orange, Groceries' happens to be green). Groceries at 199,00 €/200,00 € — 99.5% spent, one coffee away from over — renders with a plain green bar. **Why it hurts UX:** Green is the universal "safe/good" signal in a traffic-light color convention (and is literally this category's icon color too, so it's dual-coded as "fine"); showing it at 99.5% actively miscommunicates urgency, which defeats the entire purpose of a "near-limit" warning component — the near-limit *threshold* (80%) exists in the view model but has no corresponding *visual* state. **Recommendation:** add a third color tier — e.g. `.accentAmber`/`.categoryAmber` for `0.8 ≤ percent < 1.0`, reserving the category's own color for the (non-surfaced-here) under-80% state and red for over-100%. Since this component only ever renders items already ≥80%, in practice this means: amber by default, red once over.
+
+- **Severity: Medium — Problem:** The cards have no section header or label of any kind — they appear directly below the Total Balance card with zero context (confirmed in `DashboardView.swift:25-27`: bare `ForEach` after the optional anomaly callout, no `Text` header). A first-time user has no way to know these are budget-limit warnings versus, say, a generic category summary. **Why it hurts UX:** Nielsen's *recognition rather than recall* — every other grouped section on this screen and elsewhere in the app ("Recent Transactions," "EXPENSE CATEGORIES") is introduced by a label; this is the exception. **Recommendation:** add a small caption header above the `ForEach`, e.g. "NEAR BUDGET LIMIT" in the same `.textDim` caption style used elsewhere, so the cards read as a labeled group rather than ambiguous inline content.
+
+- **Severity: Medium — Problem:** The card has no tap target — no `NavigationLink`, `onTapGesture`, or `Button` anywhere in `BudgetProgressBarView.swift`. Tapping "Takeout" does nothing. **Why it hurts UX:** violates the implicit affordance every other interactive-looking card on this Dashboard sets up (Recent Transactions rows navigate to transaction detail); a card telling you you're over budget is exactly the moment a user wants to drill into *why* — the dead end is a missed, expected action (Fitts's Law / task efficiency: the natural next step requires leaving the screen and hunting for the same category in Activity or Budgets instead of one tap). **Recommendation:** make the card tappable, navigating to Activity pre-filtered to that category (the app already has category filter chips per `SearchFilters`), or to the Budgets screen scrolled to that row.
+
+- **Severity: Low — Problem:** Over/under-budget status is color-only — the amount text (`"276,00 € / 200,00 €"`) is styled identically (`.caption`, `.textDim`) regardless of whether the category is over or under budget; only the thin progress bar underneath changes color. **Why it hurts UX:** WCAG 1.4.1 (*use of color*) — a colorblind user or anyone glancing quickly has only a thin 4pt bar as the sole differentiator between "fine" and "over budget." **Recommendation:** when `isOverBudget`, also color the amount text `.negative` (or bold it), so the signal isn't carried by the progress bar alone.
+
+### Updated recommendations for this file's existing lists
+
+- Add to **Quick Wins**: the amber near-limit color tier (small, self-contained change to `barColor`); the "NEAR BUDGET LIMIT" section header.
+- Add to **High Impact Improvements**: swap to `GlassCard` (already scoped); make the card tappable.
+
 ## Redesign Suggestions
 
 ### Budgets screen — row treatment

--- a/docs/ux-audit-2026-07-29.md
+++ b/docs/ux-audit-2026-07-29.md
@@ -1,0 +1,122 @@
+# UX/UI Audit — Personal Finance Tracker — Budgets feature — 2026-07-29
+
+## Screens audited
+- **Settings / Profile sheet** — "Manage Budgets" entry point — source: screenshot
+- **Budgets screen (empty state)** — all categories showing "No limit" — source: screenshot
+- **Budgets screen (mid-edit)** — one committed value ("11111"), one row focused with decimal-pad keyboard open — source: screenshot
+- Code-level review: `PersonalFinanceTraker/Features/Budgets/BudgetRow.swift`, `PersonalFinanceTraker/Features/Budgets/BudgetsView.swift`, `PersonalFinanceTraker/Features/Dashboard/Components/BudgetProgressBarView.swift` (for cross-screen consistency comparison), `PersonalFinanceTraker/Features/EditAddTransactionView/Components/CurrencyAmountField.swift` (existing app convention for money entry)
+
+## Per-screen findings
+
+### Settings / Profile sheet — "Manage Budgets" entry
+- **Severity: Low — Problem:** The row shows only "Manage Budgets" with no count or status ("3 of 15 categories budgeted"), unlike apps that surface a summary at the entry point. **Why it hurts UX:** Nielsen's *visibility of system status* — the user can't tell budgets are configured without opening the screen. **Recommendation:** Add a trailing subtitle or count, e.g. `"3 set"`, matching the pattern many Settings-style screens use for a child screen's state.
+- **Strength (not an issue):** Placement directly under "Manage Categories" with matching row style (icon-less label + chevron) is consistent and discoverable — correct information architecture, budgets are naturally adjacent to categories.
+
+### Budgets screen (empty state — all "No limit")
+- **Severity: Medium — Problem:** ~15+ rows are visually identical (same icon size, same gray "No limit" trailing text, same row height) with the only distinguishing content the category name. There's no way to tell — without reading every row — which categories, if any, already have a budget once real data exists (the empty-state screenshot is the base case, but this same undifferentiated list is what a user with 3 budgets set among 15 categories will scroll through daily). **Why it hurts UX:** Hick's Law — decision time and scan effort scale with the number of visually-identical choices; nothing here helps the eye jump to "the ones that matter." **Recommendation:** Sort/pin categories with a budget set to the top, or add a subtle visual marker (dot, bolder amount) distinguishing "has a limit" rows from "No limit" rows.
+- **Severity: Low — Problem:** No affordance signals the trailing text is an editable field. There's no chevron, no underline, no "tap to edit" visual cue — "No limit" simply looks like inert status text (which is exactly what it looks like on every other screen in this app, e.g. `CategoryRow` uses trailing chevrons for "this row is tappable"). **Why it hurts UX:** Nielsen's *recognition rather than recall* / affordance — nothing distinguishes this row from a purely informational list row like the ones in Categories, so first-time users must discover by accidental tap that the amount is directly editable. **Recommendation:** Give the field a visible input treatment — a bordered/pill background around the amount (similar to the "21:00" pill on the Daily Reminder row in screenshot 1, which *does* correctly signal "this is a value you can change").
+- **Severity: Low — Problem:** No section-level summary (total monthly budget across all categories) despite the data being trivially available. **Why it hurts UX:** Users planning a monthly budget want the aggregate, not just per-row figures — this is present-but-uncomputed information the screen is well-positioned to surface. **Recommendation:** Add a header or footer line: "Total budgeted: €X across N categories."
+
+### Budgets screen (mid-edit — "11111" committed, "Books & Education" focused)
+- **Severity: Critical — Problem:** `BudgetRow.swift:22` — the amount `TextField` has **no currency symbol, no thousands separator, and no formatting on commit**. The screenshot shows a committed value of literally `11111` with zero visual indication of what it means — is this €111.11, €1,111.10, or €11,111? **Why it hurts UX:** This directly breaks Nielsen's *match between system and the real world* and is inconsistent with how money is displayed everywhere else in this exact app — `CurrencyAmountField.swift` (used in Add/Edit Transaction) always renders a currency symbol and locale-correct grouping, and `BudgetProgressBarView.swift` renders budget amounts as `.formatted(.currency(code: "EUR"))` (e.g. "€270.00 / €300.00") on the very same feature's Dashboard display. The editing screen and the display screen for the *same number* look completely different. **Recommendation:** On commit (or continuously via a formatted display state, matching `CurrencyAmountField`'s pattern), render the stored value with a €-prefixed, grouped, 2-decimal format. At minimum, format `displayText(for:)` (`BudgetRow.swift:35-38`) through `.formatted(.currency(code: "EUR"))` instead of raw `NSDecimalNumber.stringValue`.
+- **Severity: High — Problem:** The `.decimalPad` keyboard (`BudgetRow.swift:23`) has no Return/Done key by iOS design, and `BudgetsView.swift` adds no `.toolbar(.keyboard)` accessory bar. In the screenshot the keyboard covers roughly 40% of the screen with no visible way to close it except tapping another row (which starts editing *that* row) or scrolling. **Why it hurts UX:** Nielsen's *user control and freedom* — there is no direct, obvious way to finish and dismiss. **Recommendation:** Add a keyboard toolbar with a "Done" button that resigns focus, e.g. `.toolbar { ToolbarItemGroup(placement: .keyboard) { Spacer(); Button("Done") { isFocused = false } } }`.
+- **Severity: High — Problem:** `BudgetRow.swift:40-50` — `commit()` on invalid/empty input silently sets `monthlyBudget = nil` with no confirmation. If a user is editing an *existing* budget (e.g. clearing "300" to type a new number) and taps away mid-edit or with a malformed value, the previous budget is silently discarded — not restored, not asked about. **Why it hurts UX:** This is a data-loss pattern with no safety net (Nielsen's *error prevention*) — accidental taps during a multi-row editing session (visible in the screenshot: two rows show activity in the same view) can silently wipe a previously-set limit. **Recommendation:** On invalid input, revert to the last committed value instead of clearing to nil; only clear to nil on an explicit, deliberate action (e.g. a clear/✕ button), not as the fallback for "didn't parse."
+- **Strength:** Tapping directly from one row into the next (visible in the screenshot: "Banking Fees" shows its committed value while "Books & Education" is now focused) correctly commits the prior row via focus-loss before moving on — the underlying `onChange(of: isFocused)` commit pattern works as intended for sequential editing.
+- **Strength:** The comma-to-period normalization (`BudgetRow.swift:41`) correctly handles the European decimal-input convention shown by the comma key on the keyboard in the screenshot, matching the parse target (`Decimal(string:)`), so at least the *input* half of the localization story is handled even though the *output* formatting is not.
+
+## Cross-screen consistency issues
+
+1. **Currency formatting diverges between entry and display within the same feature.** The Budgets edit screen shows unformatted raw numbers (`11111`); the Dashboard's `BudgetProgressBarView` shows the identical kind of value fully formatted (`€270.00 / €300.00`). A user who sets a budget on one screen will see it rendered completely differently seconds later on another screen of the same feature — this is the single most visible inconsistency in the audit.
+2. **Affordance pattern mismatch.** Every other "tap to change a value" row already established in this app — `ProfilePayCycleSection`'s "Time" pill (`21:00`, screenshot 1), `CategoryRow`'s trailing chevron — uses a distinct visual treatment for "this is interactive." Budget rows use plain trailing text indistinguishable from a purely informational label (e.g. how "No limit" would read on a read-only summary screen).
+3. **Navigation asymmetry.** `CategorySettingsView` rows navigate to a modal edit sheet (`EditCategorySheet`) with explicit Save/Cancel/Delete actions; `BudgetsView` rows edit inline with an implicit, silent commit-on-blur. Both are valid patterns individually, but placed one screen away from each other under the same Settings sheet, the sudden shift from "explicit modal confirm" to "silent inline commit" is a jarring model change for the user to learn.
+
+## Executive Summary
+
+**Top 10 UX problems**
+1. No currency formatting on the amount field — raw, ambiguous numbers (Critical)
+2. No way to dismiss the decimal-pad keyboard (High)
+3. Invalid/cleared input silently discards a previously-set budget with no confirmation (High)
+4. No visual affordance signaling the amount is editable (Medium)
+5. Undifferentiated list of 15+ identical "No limit" rows, no way to scan for "what's set" (Medium)
+6. No aggregate/total budget summary (Low)
+7. No status/count on the "Manage Budgets" entry point in Settings (Low)
+8. No save confirmation (haptic/visual) after committing a value (Low)
+9. Inline-edit interaction model is inconsistent with the adjacent Categories screen's modal-edit model (Medium, cross-screen)
+10. No empty-state messaging if a user has zero expense categories (Low, unverified/code-level gap)
+
+**Top 10 UI problems**
+1. Raw unformatted number display (`11111`) vs. app-wide currency convention (Critical)
+2. Trailing amount text visually indistinguishable from static label text
+3. No keyboard accessory toolbar
+4. No visual distinction between "budgeted" and "not budgeted" rows in the list
+5. No section footer/summary
+6. Placeholder ("No limit") and set-value text share the same position/style with only color differing — easy to misread at a glance
+7. (Remaining UI findings are duplicates of UX findings above — this is primarily a UX audit with UI symptoms, not a distinct visual-design problem set.)
+
+**Biggest accessibility issues**
+- The amount `TextField` has no explicit `accessibilityLabel`/`accessibilityValue` combining the category name and current budget (`BudgetRow.swift:22`) — VoiceOver would likely announce only "No limit, text field" or the raw digits, without the category context a sighted user gets for free from the adjacent `Text(category.name)`. Recommend `.accessibilityLabel("\(category.name) budget")` on the `TextField`.
+- Cannot verify color contrast ratios precisely from compressed screenshots — the "No limit" gray-on-navy trailing text (screenshot 2) *looks* borderline against WCAG AA's 4.5:1 for normal text; flagging as an assumption to verify with a contrast checker against the actual `.textDim` token value, not a confirmed failure.
+
+**Biggest consistency issues**
+- Currency formatting: raw vs. `.formatted(.currency(code: "EUR"))` between this screen and Dashboard (see Cross-screen #1).
+- Interaction model: silent inline-commit vs. explicit modal-confirm used one screen away for Categories (see Cross-screen #3).
+
+## Quick Wins
+*(implementable in under one day)*
+- Format the amount display through `.formatted(.currency(code: "EUR"))` instead of raw `NSDecimalNumber.stringValue` (`BudgetRow.swift:35-38`).
+- Add a `.toolbar(.keyboard)` "Done" button that resigns `isFocused`.
+- Add `.accessibilityLabel` to the amount `TextField`.
+- Add a count/status subtitle to the "Manage Budgets" Settings row.
+
+## High Impact Improvements
+*(moderate effort, big UX payoff)*
+- Change invalid-input handling in `commit()` to revert to the last committed value rather than silently nulling the budget.
+- Give budgeted rows a distinct visual treatment (pill background matching `ProfilePayCycleSection`'s "Time" pill, or a leading dot) so the list scans in O(1) instead of requiring the user to read every row.
+- Add a total-budgeted summary line to the Budgets screen.
+
+## Long-term Improvements
+*(architectural/design-system changes)*
+- Establish one shared "amount entry" component (extending or reusing `CurrencyAmountField`'s formatting logic in a compact/inline variant) so every money-entry surface in the app — Add Transaction, Budgets, and any future feature — formats and parses identically, instead of each screen reimplementing its own decimal parsing.
+- Decide deliberately whether inline-silent-commit or explicit-modal-confirm is this app's standard editing pattern for settings-style data, and apply it consistently across Categories and Budgets rather than letting each feature pick independently.
+
+## UX Score (1–10)
+- **Visual Design: 6/10** — clean, on-brand dark theme, consistent with the rest of the app, but the raw unformatted amount undermines an otherwise polished screen.
+- **Usability: 5/10** — functional core loop (tap, type, blur-to-save) works, but no keyboard dismiss and silent data-loss risk on invalid input are real friction/risk points.
+- **Accessibility: 5/10** — no VoiceOver-specific labeling on the one interactive control that matters most on this screen; contrast unverified but plausible.
+- **Information Architecture: 7/10** — correct placement under Settings next to Categories; missing only a status/count signal at the entry point.
+- **Navigation: 7/10** — standard NavigationLink + back chevron, no surprises.
+- **Consistency: 4/10** — the currency-formatting mismatch with the Dashboard half of this same feature, and the interaction-model mismatch with Categories, are the audit's most damaging findings.
+- **Learnability: 5/10** — nothing signals the amount field is editable beyond discovering it by tapping; once discovered, the interaction itself is simple.
+- **Overall Experience: 5/10** — the underlying engineering (pay-cycle-aware progress computation, near-limit Dashboard callouts) is strong, but the entry screen's currency formatting gap is the kind of first-impression bug that would make a user distrust the numbers app-wide.
+
+## Redesign Suggestions
+
+### Budgets screen — row treatment
+Replace the plain trailing text with a pill-style value control (matching the existing "21:00" pattern from Profile's pay-cycle section), and format it as currency at all times:
+
+```
+┌──────────────────────────────────────────────┐
+│ 🏦  Banking Fees                    €111.10 ⌵│   <- pill background, tappable
+│ 📖  Books & Education                No limit │   <- dimmer pill, "No limit" as a real placeholder state
+└──────────────────────────────────────────────┘
+```
+
+### Budgets screen — header summary
+```
+EXPENSE CATEGORIES                    Total: €340.00
+┌──────────────────────────────────────────────┐
+│ ...rows...                                     │
+└──────────────────────────────────────────────┘
+```
+
+### Keyboard toolbar
+```
+┌──────────────────────────────────────────────┐
+│  1    2    3                                   │
+│  4    5    6                                   │
+│  7    8    9                                   │
+│  ,    0    ⌫                                   │
+├──────────────────────────────────────────────┤
+│                                          Done  │  <- new accessory bar
+└──────────────────────────────────────────────┘
+```

--- a/docs/ux-audit-2026-07-30.md
+++ b/docs/ux-audit-2026-07-30.md
@@ -1,0 +1,99 @@
+# UX/UI Audit — Personal Finance Tracker — Dashboard screen — 2026-07-30
+
+## Screens audited
+- **Dashboard, scroll top** — Greeting, Total Balance card, This Month stats, three "Near Budget Limit" cards — source: screenshot
+- **Dashboard, scrolled down** — tail of budget cards under the nav bar, Recent Transactions list, trailing empty space — source: screenshot
+- Code-level review: `Features/Dashboard/DashboardView.swift`, `Features/Dashboard/Components/GreetingHeaderView.swift`, `BalanceCardView.swift`, `AnomalyCalloutView.swift`, `BudgetProgressBarView.swift`, `RecentTransactionsSectionView.swift`, `Features/TransactionListView/Components/StatCard.swift`, `Utilities/AppToolbarModifier.swift`, `Utilities/BudgetProgressService.swift`
+
+## Per-screen findings
+
+### Dashboard — overall structure
+- **Severity: High — Problem:** `DashboardView.swift` sets `.navigationBarTitleDisplayMode(.inline)` but never calls `.navigationTitle(...)`, so the nav bar has no title and no opaque/material background — it's a fully transparent overlay holding only the gear and `+` buttons. Confirmed in the second screenshot: the top of the "Banking Fee..." card is visible faded/ghosted directly behind the gear icon as the user scrolls, because scrolled content passes *underneath* the toolbar buttons instead of being visually separated by a bar. **Why it hurts UX:** Nielsen's *aesthetic and minimalist design* / legibility — content overlapping interactive controls is a readability and mis-tap risk (the gear button's tap target sits directly on top of card content once scrolled), and it reads as visually broken rather than intentional. **Recommendation:** give the toolbar a background material on scroll, e.g. `.toolbarBackground(.ultraThinMaterial, for: .navigationBar)` with `.toolbarBackgroundVisibility(.automatic, for: .navigationBar)`, or add `.background(.bar)` scoped to the toolbar area, so scrolled content is masked before it reaches the buttons.
+- **Severity: Medium — Problem:** `ForEach(viewModel.nearLimitBudgets)` (`DashboardView.swift:33-38`, now inside `GlassEffectContainer`) has no cap on how many cards render. In the current test data, all three budgeted categories are simultaneously near/over limit, so the Dashboard opens with three consecutive red/amber alert cards stacked directly under the balance — every visible signal on first glance is a warning, none neutral. With more categories this scales linearly: a user with 8 near-limit categories would see 8 stacked alert cards before ever reaching Recent Transactions. **Why it hurts UX:** Nielsen's *aesthetic and minimalist design* and alarm fatigue — a home screen dominated entirely by red is either overwhelming (many alerts) or, with only a couple, disproportionately alarming relative to the actual severity (a card at exactly 80% reads with the same visual weight as one at 300%). **Recommendation:** cap the Dashboard to the top N (e.g. 3, already true today by coincidence) sorted by severity (already sorted via `BudgetProgressService.nearLimit`'s descending sort), and if `nearLimitBudgets.count` exceeds the cap, add a trailing "+2 more near limit →" row linking to the Budgets screen instead of rendering every card inline.
+- **Severity: Low — Problem:** `GreetingHeaderView.swift:13` renders a static, unpersonalized "Good morning" with no user name, icon, or date — despite `ProfileViewModel` almost certainly having the user's name available (used elsewhere in the Profile sheet as "Your Name"). **Why it hurts UX:** a missed, low-cost opportunity for warmth/personalization that most finance apps in this category use, not a functional defect. **Recommendation:** low priority — consider "Good morning, {name}" if `ProfileViewModel` exposes a first name.
+
+### Near Budget Limit cards (re-verified after recent fixes)
+- **Strength:** The `GlassEffectContainer` + `GlassCard` fix from this session's earlier work is confirmed working in these screenshots — all three cards now render with visually consistent, distinguishable backgrounds against the page background and against each other. The amber/red tiering (Banking Fees, Takeout = red/over; Groceries = amber/near) is also confirmed rendering correctly.
+- **Severity: Low — Problem:** `BudgetProgressBarView` still has no combined VoiceOver element — the category icon, name, and "spent / budget" text are three separate elements with no `accessibilityElement(children: .combine)`, and the `ProgressView`'s value isn't given a custom `accessibilityLabel` describing "over budget" vs. "near limit" (this was flagged generally in the 2026-07-29 report but re-confirmed still present after this session's edits). **Why it hurts UX:** WCAG / screen-reader friendliness — VoiceOver users get three disjoint announcements per card instead of one coherent one ("Banking Fees, 100 euros of 20 euros, over budget"). **Recommendation:** wrap the `VStack` in `.accessibilityElement(children: .combine)` and add an explicit `.accessibilityLabel` summarizing status.
+
+### Recent Transactions
+- **Severity: Low — Problem:** The fourth transaction row ("Other", screenshot 2) renders a gray square with a bare `"?"` glyph instead of a category icon. **Why it hurts UX:** a `"?"` icon reads as a data/rendering error to users (broken state), not as an intentional "uncategorized" affordance — Nielsen's *match between system and the real world*, this looks like a bug even if it's a deliberate fallback. **Recommendation:** give the "no category"/"Other" fallback state a purpose-built icon (e.g. `tray` or `ellipsis.circle`) distinct from an error-coded question mark, and confirm in code whether this is truly an uncategorized transaction or a category lookup failure (worth a quick source check, not confirmed from the screenshot alone).
+- **Severity: Low — Problem:** After the 5-row Recent Transactions list, screenshot 2 shows a large empty area (roughly 40% of remaining screen height) before the tab bar — `Spacer(minLength: 80)` (`DashboardView.swift:51`) combined with a short transaction list leaves a lot of dead space with no content, guidance, or call to action. **Why it hurts UX:** empty, purposeless space on a primary screen is a missed opportunity — Nielsen's *recognition rather than recall*/*minimalist design* cuts both ways: too little content in a large area can look unfinished rather than clean. **Recommendation:** either reduce the fixed spacer to only what's needed to clear the tab bar (typically ~100pt is enough; 80 is already close, so the gap here is really "not enough content" rather than "too much spacer") or consider adding a lightweight prompt/CTA below Recent Transactions when the list is short (e.g. "View all transactions →" link to Activity).
+- **Strength:** `RecentTransactionsSectionView`'s divider-separated `GlassCard` list, tap-to-edit via `Button` + `TransactionItemView`, and category-colored icon squares are clean, consistent, and match the established list pattern used elsewhere in the app (Categories, Budgets).
+
+## Cross-screen consistency issues
+
+1. **Toolbar transparency is Dashboard-specific in its visible impact.** Other tabs (Activity, Insights) use the same `AppToolbarModifier`/transparent nav bar, but Dashboard is the only screen where content scrolls close enough to the top edge with high-contrast card backgrounds (`GlassCard`) to make the overlap visually obvious — worth checking Activity/Insights too, since the underlying cause (`AppToolbarModifier.swift` — no `.toolbarBackground`) is shared app-wide, not unique to this file.
+2. **`GlassCard` is now used for 4 distinct purposes on this one screen** (Total Balance, This Month stat pair via tinted `StatCard`, Near Budget Limit cards, Recent Transactions) with 3 different tint/radius configurations (`nil`/26, `color.opacity(0.1)`/16, `nil`/26). This is coherent as "the app's card system," not a defect, but confirms the earlier Budgets-audit's "Long-term Improvement" recommendation (a formal shared amount-entry/card design language) is worth revisiting holistically now that this screen has four separate `GlassCard` call sites with slightly different configuration choices.
+
+## Executive Summary
+
+**Top 10 UX problems**
+1. Scrolled content visually overlaps/hides behind the transparent toolbar buttons (High)
+2. No cap on how many "Near Budget Limit" alert cards can stack on the home screen (Medium)
+3. `BudgetProgressBarView` still lacks combined VoiceOver accessibility (Low, carried over from 2026-07-29 audit)
+4. Large empty space below a short Recent Transactions list with no content or CTA (Low)
+5. "Other" category fallback icon reads as an error state, not an intentional design choice (Low)
+6. Static, unpersonalized greeting despite user name likely being available (Low)
+
+**Top 10 UI problems**
+1. No toolbar background material — buttons float directly over scrolling card content (High)
+2. Four different `GlassCard` configurations on one screen with no documented system for when to use which (Low, architectural)
+3. "?" fallback icon looks visually broken next to properly-iconified category rows
+
+**Biggest accessibility issues**
+- No combined accessibility element on `BudgetProgressBarView` (icon/name/amount/status announced as 3 disjoint VoiceOver stops instead of one coherent summary).
+- The gear button's tap target visually collides with scrolled card content when the toolbar has no background — a mis-tap risk for any user, compounded for low-vision users relying on visual button boundaries.
+
+**Biggest consistency issues**
+- The transparent-toolbar-over-content issue is architectural (`AppToolbarModifier.swift`), so it likely affects every tab, not just Dashboard — flagged here because Dashboard's high-contrast cards make it visible first.
+
+## Quick Wins
+*(implementable in under one day)*
+- Add `.toolbarBackground(.ultraThinMaterial, for: .navigationBar)` to `AppToolbarModifier` so scrolled content no longer shows through/behind the gear and `+` buttons.
+- Replace the "Other" category's `"?"` fallback icon with a non-error-coded glyph (e.g. `tray` or `ellipsis.circle`).
+- Add `.accessibilityElement(children: .combine)` + a descriptive `.accessibilityLabel` to `BudgetProgressBarView`.
+
+## High Impact Improvements
+*(moderate effort, big UX payoff)*
+- Cap `nearLimitBudgets` rendering on Dashboard to a fixed number (e.g. top 3, already sorted by severity) with a "+N more near limit" link to the Budgets screen once a user has more than a few categories in warning state, so the home screen doesn't become dominated by alert cards as usage grows.
+- Add a lightweight CTA or secondary content below Recent Transactions when the list is short, to use the empty space purposefully instead of leaving it dead.
+
+## Long-term Improvements
+*(architectural/design-system changes)*
+- Formalize the `GlassCard` usage patterns (tint, radius, when to nest in a `GlassEffectContainer`) into documented conventions now that this one screen alone has four different configurations — this session's contrast/tap-target/rendering bugs on `BudgetProgressBarView` all stemmed from not following the established pattern used by `BalanceCardView`/`RecentTransactionsSectionView`; a documented convention would prevent the same class of bug on the next new card.
+
+## UX Score (1–10)
+- **Visual Design: 6/10** — clean dark theme, consistent card language, but the toolbar-overlap issue and "?" icon undercut the polish.
+- **Usability: 6/10** — core information (balance, budgets, recent activity) is all reachable in one scroll, but the toolbar overlap creates a real mis-tap/legibility risk right where users tap most (Settings, Add).
+- **Accessibility: 5/10** — no VoiceOver-combining on the newest component (budget cards); rest of the screen is standard SwiftUI defaults, unverified for full compliance.
+- **Information Architecture: 7/10** — logical top-to-bottom priority (balance → warnings → recent activity), correctly surfaces the most urgent information first.
+- **Navigation: 7/10** — standard, no surprises; budget cards' new tap-through to Activity is a genuine improvement confirmed working in this session.
+- **Consistency: 6/10** — shared `GlassCard` system used throughout, but with enough per-instance variation to suggest it's ad hoc rather than governed by a documented pattern.
+- **Learnability: 7/10** — nothing on this screen requires explanation; layout and iconography are self-evident.
+- **Overall Experience: 6/10** — a functional, mostly polished home screen let down by one concrete rendering bug (toolbar overlap) and one scalability gap (unbounded alert cards) that will get worse, not better, as real user data grows.
+
+## Redesign Suggestions
+
+### Dashboard — toolbar overlap fix
+```
+┌──────────────────────────────────────────────┐
+│ ░░░░░░░░░░░ material background ░░░░░░░░░░░░░ │  <- .toolbarBackground(.ultraThinMaterial)
+│  ⚙                                          + │
+├──────────────────────────────────────────────┤
+│  Good morning                                  │
+│  ...scrolled content, now clearly separated... │
+└──────────────────────────────────────────────┘
+```
+
+### Near Budget Limit — capped list
+```
+NEAR BUDGET LIMIT
+┌──────────────────────────────────────────────┐
+│ 💳 Banking Fees          100,00 € / 20,00 €    │
+│ 🥡 Takeout               276,00 € / 200,00 €    │
+│ 🛒 Groceries             199,00 € / 200,00 €    │
+├──────────────────────────────────────────────┤
+│  +2 more near limit                          → │  <- appears only when count exceeds cap
+└──────────────────────────────────────────────┘
+```


### PR DESCRIPTION
## Summary
- Adds a full Budgets feature: per-category monthly spending limits, settable inline on a dedicated Budgets screen (`Profile → Manage Budgets`), with pay-cycle-aware progress computed via `BudgetProgressService`.
- Dashboard surfaces categories near/over their limit as tappable cards (amber near-limit / red over-budget), deep-linking into Activity pre-filtered to that category.
- Fixes found via `/ux-audit` passes on the new screens: revert-on-invalid budget input (no more silent data loss), budgeted-row visual indicators + total-budgeted summary, shared `AmountParser` utility adopted across 4 money-entry screens, Profile bottom-sheet navigation bug (`NavigationLink` + `.simultaneousGesture` was swallowing taps on 3 rows), Liquid Glass rendering/tap-target fixes on the near-limit cards, and VoiceOver/icon accessibility improvements.
- **Known incomplete, called out in commit `faf4a9e`:** Dashboard's toolbar buttons can still overlap scrolled content at some scroll positions — a `.safeAreaInset`-based fixed-height spacer wasn't tall enough on-device. Left as a follow-up; the fix direction (replace `ToolbarItem`s with a custom `.safeAreaInset` header so reserved space and buttons are the same view) is already scoped.

## Test plan
- [x] Full build green via Xcode MCP
- [x] Full test suite: 265/268 passing (3 known pre-existing failures unrelated to this branch — 2 `XLSXExportServiceTests`, 1 flaky PIN test)
- [x] New `AmountParserTests` (12/12) and `BudgetProgressServiceTests` (8/8) passing
- [x] Manually verified in simulator: budget entry/edit/revert, Dashboard near-limit cards tap-through to filtered Activity, Profile navigation to Budgets/Categories/Change PIN
- [ ] Re-verify the known toolbar-overlap issue once addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)