### PR TITLE
fix: localize backup/restore UI and fix misaligned CTA

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -27,9 +27,9 @@ struct ProfileView: View {
     private let pinService = PINService()
     private let backupService = BackupService()
 
-    private var backupStatusText: String {
+    private var backupStatusTitle: String {
         guard let lastBackupDate = appSettings.lastBackupDate else {
-            return "Not backed up — enable iCloud Drive to protect against app deletion"
+            return "Not backed up"
         }
         let formatter = RelativeDateTimeFormatter()
         return "Last backup: \(formatter.localizedString(for: lastBackupDate, relativeTo: .now))"
@@ -113,15 +113,23 @@ struct ProfileView: View {
                             Label("Export Data", systemImage: "square.and.arrow.up")
                         }
 
-                        HStack {
-                            Label(backupStatusText, systemImage: appSettings.lastBackupDate != nil ? "checkmark.icloud" : "exclamationmark.icloud")
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label(backupStatusTitle, systemImage: appSettings.lastBackupDate != nil ? "checkmark.icloud" : "exclamationmark.icloud")
                                 .foregroundStyle(appSettings.lastBackupDate != nil ? .textDim : .negative)
-                            Spacer()
-                            Button("Backup Now") {
+
+                            if appSettings.lastBackupDate == nil {
+                                Text("Enable iCloud Drive to protect your data if the app is deleted.")
+                                    .font(.caption)
+                                    .foregroundStyle(.textDim)
+                            }
+
+                            Button("Back Up Now") {
                                 Task { await runManualBackup() }
                             }
-                            .font(.caption)
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
+                        .padding(.vertical, 4)
 
                         Button {
                             showingRestoreConfirmation = true

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
@@ -1,6 +1,126 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Not backed up" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup non eseguito"
+          }
+        }
+      }
+    },
+    "Enable iCloud Drive to protect your data if the app is deleted." : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita iCloud Drive per proteggere i tuoi dati in caso di cancellazione dell'app."
+          }
+        }
+      }
+    },
+    "Last backup: %@" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo backup: %@"
+          }
+        }
+      }
+    },
+    "Back Up Now" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esegui backup ora"
+          }
+        }
+      }
+    },
+    "Restore from Backup" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristina da backup"
+          }
+        }
+      }
+    },
+    "Restore" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristina"
+          }
+        }
+      }
+    },
+    "Backup Failed" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup non riuscito"
+          }
+        }
+      }
+    },
+    "No transactions to back up yet." : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna transazione da salvare."
+          }
+        }
+      }
+    },
+    "iCloud Drive is not available. Enable it in Settings to back up your data." : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud Drive non è disponibile. Abilitalo nelle Impostazioni per eseguire il backup dei tuoi dati."
+          }
+        }
+      }
+    },
+    "Backup failed: %@" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup non riuscito: %@"
+          }
+        }
+      }
+    },
+    "Restore Failed" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristino non riuscito"
+          }
+        }
+      }
+    },
+    "This replaces all current data with your last backup. This cannot be undone." : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo sostituirà tutti i dati attuali con l'ultimo backup. L'operazione non può essere annullata."
+          }
+        }
+      }
+    },
     "" : {
 
     },


### PR DESCRIPTION
- Add Italian translations for every backup/restore string (status, explainer, buttons, alerts, confirmation dialog) — previously hardcoded English on an otherwise fully localized screen.
- Restructure the not-backed-up row into a VStack (status + explainer + button) instead of an HStack with the button pinned beside wrapped text, and give "Back Up Now" a bordered style for a clear touch target.

Addresses the /ux-audit findings on the Settings backup row.