### PR TITLE
fix(test): make FinancialHealthService savings assertions locale-independent

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Insights/FinancialHealthServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Insights/FinancialHealthServiceTests.swift
@@ -30,7 +30,9 @@ struct FinancialHealthServiceTests {
             budgetedCategories: [],
             ignoreSubscriptions: false
         )
-        let savings = result.components.first { $0.name == "Savings rate" }!
+        // Savings is always the first component (see FinancialHealthService.compute);
+        // match by position rather than localized name so the test is locale-independent.
+        let savings = result.components[0]
         #expect(savings.tip == nil)
     }
 
@@ -45,7 +47,9 @@ struct FinancialHealthServiceTests {
             budgetedCategories: [],
             ignoreSubscriptions: false
         )
-        let savings = result.components.first { $0.name == "Savings rate" }!
+        // Savings is always the first component (see FinancialHealthService.compute);
+        // match by position rather than localized name so the test is locale-independent.
+        let savings = result.components[0]
         #expect(savings.tip != nil)
     }
 


### PR DESCRIPTION
## Problem
`FinancialHealthServiceTests.savingsTipNilWhenMaxed()` and `savingsTipPresentWhenBelowMax()` matched score components by the **localized** display name literal `"Savings rate"`:

```swift
let savings = result.components.first { $0.name == "Savings rate" }!
```

`ScoreComponent.name` is built with `String(localized: "Savings rate")`. In a non-English locale the name resolves to a translation (Italian → `"Tasso di risparmio"`), so `first` returns `nil`, the force-unwrap crashes with a fatal error, and the **entire test run aborts**.

Evidence (run in the default simulator locale):
```
names=["Tasso di risparmio", "Stabilità", "Budget", "Abbonamenti"]
preferred=["it-IT", "en-GB"]  mainLoc=["it"]
```

## Fix
Match the savings component by its **fixed position** (`components[0]`) instead of its localized name — `compute()` always builds savings first. Locale-independent, no production code change.

## Verification
`FinancialHealthService` suite: **7/7 passing** in the Italian locale (previously crashed).

Note: a scheme `language="en"` pin was tried first but is ignored by the xcodebuild test runner, so the position-based fix was chosen as the robust option.