### PR TITLE
fix: serialize PINConfirmationViewModelTests to prevent Keychain race

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
@@ -3,6 +3,7 @@ import Foundation
 
 @testable import PersonalFinanceTraker
 
+@Suite(.serialized)
 @MainActor
 struct PINConfirmationViewModelTests {
     private let pinService = PINService()


### PR DESCRIPTION
## Problem
`PINConfirmationViewModelTests.correctPINEntered()` and `incorrectPINEntered()` were flaky.

## Root cause
`PINService` stores the PIN in the Keychain under fixed, non-namespaced keys (`pft.pin_hash`/`pft.pin_salt`). Swift Testing runs tests within a suite concurrently by default, so the two tests raced on that shared Keychain entry — one test's `setPIN`/`clearPIN` clobbered the PIN the other was mid-verification on.

## Fix
Add `@Suite(.serialized)`, matching the pattern already used by `PINSetupViewModelTests` and every other suite touching shared global state (Keychain/UserDefaults).

## Verification
Build succeeded; `PINConfirmationViewModelTests` now passes 4/4 (previously failing `correctPINEntered()` and `incorrectPINEntered()` included).