### PR TITLE
fix: stop false-positive spending-spike callouts on dashboard

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ChartDataService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ChartDataService.swift
@@ -20,7 +20,7 @@ class ChartDataService {
         case .week:
             return generateWeeklyData(from: filteredItems, referenceDate: referenceDate)
         case .month:
-            return generateMonthlyData(from: filteredItems, referenceDate: referenceDate)
+            return generateMonthlyData(from: filteredItems, referenceDate: referenceDate, payCycleStartDay: payCycleStartDay)
         case .year:
             return generateYearlyData(from: filteredItems, referenceDate: referenceDate)
         }
@@ -62,22 +62,28 @@ class ChartDataService {
         return data.reversed()
     }
 
-    private func generateMonthlyData(from items: [TransactionSnapshot], referenceDate: Date) -> [ChartDataPoint] {
+    // ponytail: weeks anchored to the financial-month start (not rolling from "today"), so
+    // every day in the month lands in exactly one bucket, matching what filterItems(for: .month) kept.
+    private func generateMonthlyData(from items: [TransactionSnapshot], referenceDate: Date, payCycleStartDay: Int) -> [ChartDataPoint] {
         let calendar = Calendar.current
+        let monthStart = PayCycleService.financialMonthStart(for: referenceDate, startDay: payCycleStartDay, calendar: calendar)
+        let monthEnd = calendar.date(byAdding: .month, value: 1, to: monthStart) ?? monthStart
+
         var data: [ChartDataPoint] = []
-
-        for i in 0..<4 {
-            let weekStart = calendar.date(byAdding: .weekOfYear, value: -i, to: referenceDate) ?? referenceDate
-            let weekEnd = calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart) ?? weekStart
-
+        var weekStart = monthStart
+        var weekNumber = 1
+        while weekStart < monthEnd {
+            let weekEnd = min(calendar.date(byAdding: .day, value: 7, to: weekStart) ?? monthEnd, monthEnd)
             let weekItems = items.filter { $0.timestamp >= weekStart && $0.timestamp < weekEnd }
             let income = calculateIncome(from: weekItems)
             let expenses = calculateExpenses(from: weekItems)
 
-            data.append(ChartDataPoint(period: "Week \(4-i)", income: income, expenses: expenses, date: weekStart))
+            data.append(ChartDataPoint(period: "Week \(weekNumber)", income: income, expenses: expenses, date: weekStart))
+            weekStart = weekEnd
+            weekNumber += 1
         }
 
-        return data.reversed()
+        return data
     }
 
     private func generateYearlyData(from items: [TransactionSnapshot], referenceDate: Date) -> [ChartDataPoint] {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/TimelineAnomalyService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/TimelineAnomalyService.swift
@@ -10,6 +10,13 @@ struct TimelineAnomalyService {
         let values = raw.map { Double(truncating: $0.expenses as NSDecimalNumber) }
         guard !values.isEmpty else { return [] }
 
+        // ponytail: need real history before anything counts as "unusual" — otherwise
+        // a lone transaction against a run of empty weeks (e.g. day one after install)
+        // trivially clears mean + 1.5σ and gets flagged as a spike.
+        guard values.filter({ $0 > 0 }).count >= 3 else {
+            return raw.map { TimelineDataPoint(date: $0.date, period: $0.period, expenses: $0.expenses, isSpike: false) }
+        }
+
         let mean = values.reduce(0, +) / Double(values.count)
         let variance = values.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(values.count)
         let threshold = mean + 1.5 * variance.squareRoot()

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Dashboard/DashboardViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Dashboard/DashboardViewModelTests.swift
@@ -143,22 +143,28 @@ struct DashboardViewModelTests {
         #expect(vm.monthlyExpenses == 0)
     }
 
+    /// Three quiet baseline weeks (-200 each) plus one clear outlier week (-1000),
+    /// all inside the current financial month — a real week-over-week spike.
+    private func spikeTransactions() -> [TransactionSnapshot] {
+        let (monthStart, _) = PayCycleService.currentFinancialMonth(startDay: 1)
+        let calendar = Calendar.current
+        return [0, 8, 15, 22].enumerated().map { index, dayOffset in
+            let date = calendar.date(byAdding: .day, value: dayOffset, to: monthStart)!
+            let amount: Decimal = index == 3 ? -1000 : -200
+            return TransactionSnapshot.test(timestamp: date, amount: amount, category: "Shopping")
+        }
+    }
+
     @Test func anomalyCalloutDetectsSpike() {
-        // One large expense today, otherwise-quiet pay cycle → spike week flagged
-        let transactions = [
-            TransactionSnapshot.test(timestamp: .now, amount: -1000, category: "Shopping")
-        ]
         let callout = DashboardViewModel.computeAnomalyCallout(
-            transactions, payCycleStartDay: 1, dismissedKey: nil
+            spikeTransactions(), payCycleStartDay: 1, dismissedKey: nil
         )
         #expect(callout != nil)
         #expect(callout?.message.contains("€") == true)
     }
 
     @Test func anomalyCalloutRespectsDismissal() {
-        let transactions = [
-            TransactionSnapshot.test(timestamp: .now, amount: -1000, category: "Shopping")
-        ]
+        let transactions = spikeTransactions()
         let first = DashboardViewModel.computeAnomalyCallout(
             transactions, payCycleStartDay: 1, dismissedKey: nil
         )
@@ -171,6 +177,18 @@ struct DashboardViewModelTests {
     @Test func anomalyCalloutNilWithoutSpike() {
         let callout = DashboardViewModel.computeAnomalyCallout(
             [], payCycleStartDay: 1, dismissedKey: nil
+        )
+        #expect(callout == nil)
+    }
+
+    @Test func anomalyCalloutNilForFirstEverTransaction() {
+        // Clean install, user logs their very first transaction — no baseline to compare
+        // against, so this must never be flagged as "unusually high".
+        let transactions = [
+            TransactionSnapshot.test(timestamp: .now, amount: -1000, category: "Shopping")
+        ]
+        let callout = DashboardViewModel.computeAnomalyCallout(
+            transactions, payCycleStartDay: 1, dismissedKey: nil
         )
         #expect(callout == nil)
     }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/TimelineAnomalyServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/TimelineAnomalyServiceTests.swift
@@ -30,6 +30,18 @@ struct TimelineAnomalyServiceTests {
         #expect(result.dropLast().allSatisfy { !$0.isSpike })
     }
 
+    @Test func fewerThanThreeNonZeroWeeksNeverSpike() {
+        // Only 2 nonzero weeks — not enough baseline, even though 1000 alone
+        // would clear mean + 1.5σ against these values.
+        let input = [
+            point("Jan", expenses: 0),
+            point("Feb", expenses: 200),
+            point("Mar", expenses: 1000),
+        ]
+        let result = TimelineAnomalyService().annotateWithSpikes(input)
+        #expect(result.allSatisfy { !$0.isSpike })
+    }
+
     @Test func zeroExpensesAreNeverSpikes() {
         let input = [
             point("Jan", expenses: 0),


### PR DESCRIPTION
## Summary
The "Unusually high spending in Week N" dashboard callout had two bugs:

1. **Week buckets didn't match the filtered range.** The month view grouped transactions into 4 rolling 7-day windows counted backward from *today*, ignoring `payCycleStartDay`. Days inside the financial month but outside that rolling 28-day window were silently dropped from the mean/threshold calculation.
2. **No baseline requirement.** The spike check (`mean + 1.5σ`) ran on as few as 1-2 data points, so a single transaction against otherwise-empty weeks — e.g. a user's very first transaction after a clean install — trivially cleared the threshold and got flagged as "unusually high."

## Fix
- `ChartDataService.generateMonthlyData` now buckets weeks starting from the financial-month start (`PayCycleService.financialMonthStart`), walking forward in contiguous 7-day windows through month end, so every transaction lands in exactly one bucket.
- `TimelineAnomalyService.annotateWithSpikes` now requires at least 3 nonzero weeks of data before flagging anything as a spike.

## Testing
- Added `fewerThanThreeNonZeroWeeksNeverSpike` and `anomalyCalloutNilForFirstEverTransaction` to cover the reported cases.
- Rewrote the existing spike tests to use a real 3-week baseline + outlier instead of a lone transaction.
- Full suite: 356/356 passing; targeted `TimelineAnomalyServiceTests` + `DashboardViewModelTests`: 21/21 passing.