### PR TITLE
fix: prevent duplicate Face ID prompt on cold launch

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BiometricAuthService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BiometricAuthService.swift
@@ -29,6 +29,9 @@ public class BiometricAuthService: ObservableObject, BiometricAuthenticating {
     }
 
     private let kBiometricLockEnabled = "biometric_lock_enabled"
+    // ponytail: plain Bool guard, not an actor — authenticate() is only ever called
+    // from the main thread (SwiftUI onAppear/onChange callbacks).
+    private var isAuthenticating = false
 
     public init() {
         checkBiometrics()
@@ -56,6 +59,11 @@ public class BiometricAuthService: ObservableObject, BiometricAuthenticating {
             return
         }
 
+        // Cold launch fires this from both onAppear's splash timer and the scenePhase
+        // transition to .active; without this guard the second call opens a second,
+        // overlapping Face ID prompt while the first is still awaiting the user.
+        guard !isAuthenticating else { return }
+
         // Create a fresh context for each evaluation (LAContext is single-use).
         let authContext = LAContext()
         var error: NSError?
@@ -68,8 +76,10 @@ public class BiometricAuthService: ObservableObject, BiometricAuthenticating {
             return
         }
 
+        isAuthenticating = true
         authContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
             DispatchQueue.main.async {
+                self.isAuthenticating = false
                 self.isUnlocked = success
                 completion(success)
             }


### PR DESCRIPTION
## Problem
On cold launch, Face ID is prompted twice: the first prompt unlocks the app and shows the dashboard, the second appears to do nothing.

## Root cause
`AuthenticationWrapper` has two independent triggers that both call `authService.authenticate()`:
- `onAppear`'s 0.8s splash timer (covers cold launch, where there's no scenePhase *transition* to catch)
- `onChange(of: scenePhase)` firing to `.active` (covers foreground-after-background)

On cold launch iOS delivers a scenePhase transition to `.active` almost immediately, so both fire within the same short window. Neither call site (nor `BiometricAuthService.authenticate()` itself) guarded against an authentication already in flight, so the first Face ID challenge was still awaiting the user when the second call opened a second, overlapping `LAContext.evaluatePolicy` challenge.

## Fix
Added an `isAuthenticating` in-flight guard inside `BiometricAuthService.authenticate()` — a second call while one is pending is now a no-op. Fixed at the service layer (the actual point of hardware contention) rather than trying to guess in view code which of the two legitimate triggers should win.

## Testing
- Build succeeds via Xcode MCP.
- Not unit-testable: the guarded branch only executes past `canEvaluatePolicy`, which returns `false` in CI/simulator (no enrolled biometrics).
- Manual verification pending on device (only one Face ID prompt on cold launch with biometric lock enabled).