### PR TITLE
fix: cover screen in task switcher to hide sensitive data

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
@@ -50,9 +50,18 @@ struct AuthenticationWrapper: View {
                     .transition(.opacity)
                     .zIndex(1)
             }
+
+            // ponytail: covers the task-switcher snapshot, which is taken on
+            // .inactive (before .background triggers the PIN lock below).
+            if scenePhase != .active && !showSplash {
+                SplashView()
+                    .transition(.opacity)
+                    .zIndex(1)
+            }
         }
         .animation(.easeInOut(duration: 0.25), value: isPINSetup)
         .animation(.easeInOut(duration: 0.25), value: authService.isUnlocked)
+        .animation(.easeInOut(duration: 0.25), value: scenePhase)
         .onAppear {
             if !isPINSetup {
                 try? pinService.clearPIN()


### PR DESCRIPTION
## Problem
Task-switcher snapshots are taken when `scenePhase` becomes `.inactive` — one phase before `.background`, which is what triggers the existing PIN lock. So the app switcher preview showed real balances/transactions.

## Fix
Show the existing `SplashView` cover whenever `scenePhase != .active`, matching the pattern already used for the launch splash.

## Testing
- Build succeeds via Xcode MCP.
- Manual: backgrounded the app and checked the app switcher preview shows the splash cover instead of transaction data.