### PR TITLE
Security hardening: PIN lockout, PBKDF2, encrypted backups, at-rest protection

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AddTransactionIntent.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AddTransactionIntent.swift
@@ -5,6 +5,7 @@
 
 import AppIntents
 import Foundation
+import UIKit
 
 enum QuickAddType: String, AppEnum {
     case expense, income
@@ -63,6 +64,12 @@ struct AddTransactionIntent: AppIntent {
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
+        // Fail gracefully if the device is locked and the store is protected.
+        // When `.complete` protection is active, the store is inaccessible until unlock.
+        guard UIApplication.shared.isProtectedDataAvailable else {
+            return .result(dialog: "Unlock your phone to add a transaction.")
+        }
+
         let repo = TransactionActor.make(AppContainer.shared)
         let categories = try await repo.fetchCategories()
         let input = try QuickAddService.makeInput(

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
@@ -14,6 +14,12 @@ enum AppContainer {
     /// Minimal in-app recovery: display a message, offer app restart/reinstall options.
     static var containerCreationError: Error?
 
+    /// Check if a container creation error occurred and return a user-facing message.
+    static var containerErrorMessage: String? {
+        guard let error = containerCreationError else { return nil }
+        return "Unable to access your data. Please restart the app or reinstall if the issue persists."
+    }
+
     static let shared: ModelContainer = {
         let schema = Schema([
             TransactionModel.self,
@@ -101,10 +107,12 @@ enum AppContainer {
         }
 
         let fileManager = FileManager.default
+        // SQLite sidecars use -wal and -shm suffixes appended directly to the store path,
+        // not additional extensions. Protect main file + both sidecars.
         let files = [
-            url.appendingPathExtension("sqlite"),
-            url.appendingPathExtension("sqlite-wal"),
-            url.appendingPathExtension("sqlite-shm"),
+            url,
+            URL(fileURLWithPath: url.path + "-wal"),
+            URL(fileURLWithPath: url.path + "-shm"),
         ]
 
         for file in files {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
@@ -5,10 +5,15 @@
 
 import Foundation
 import SwiftData
+import UIKit
 
 /// Single shared container — used by the app scene and by App Intents, which
 /// run in-process but can't reach the App struct's instance property.
 enum AppContainer {
+    /// Error state when ModelContainer creation fails.
+    /// Minimal in-app recovery: display a message, offer app restart/reinstall options.
+    static var containerCreationError: Error?
+
     static let shared: ModelContainer = {
         let schema = Schema([
             TransactionModel.self,
@@ -34,9 +39,41 @@ enum AppContainer {
             // debug or release, needs them to add a transaction. Always reseed when
             // empty, including right after Delete All Data wipes CategoryModel.
             MainActor.assumeIsolated { seedDefaultCategoriesIfNeeded(in: container) }
+
+            // Harden the store file protection so the SQLite database is unreadable
+            // while the device is locked. Must be called after container creation.
+            if let storeURL = modelConfiguration.url {
+                hardenStore(at: storeURL)
+            }
+
             return container
         } catch {
-            fatalError("Could not create ModelContainer: \(error)")
+            // Store the error for graceful recovery UI instead of crashing.
+            containerCreationError = error
+            // Return a dummy in-memory container so the app can boot and show the error.
+            let fallbackSchema = Schema([
+                TransactionModel.self,
+                CategoryModel.self,
+                CreditCardModel.self,
+                GoalModel.self,
+                HealthScoreSnapshot.self,
+                DailyForecastCache.self,
+                RecurrenceRule.self,
+            ])
+            let fallbackConfig = ModelConfiguration(
+                schema: fallbackSchema,
+                isStoredInMemoryOnly: true
+            )
+            do {
+                return try ModelContainer(
+                    for: fallbackSchema,
+                    configurations: [fallbackConfig]
+                )
+            } catch {
+                // Absolute fallback — something is deeply broken. Let the app crash
+                // so it can be debugged, but log the original error.
+                fatalError("Could not create ModelContainer (original: \(containerCreationError ?? error))")
+            }
         }
     }()
 
@@ -49,5 +86,40 @@ enum AppContainer {
             context.insert(category)
         }
         try? context.save()
+    }
+
+    /// Harden the SwiftData store's file protection so the SQLite database is
+    /// unreadable while the device is locked. Guards with isProtectedDataAvailable
+    /// and silently skips if protection is not possible — the next launch will retry.
+    /// ponytail: hardening can fail if device is locked; gracefully retry on next launch.
+    private static func hardenStore(at url: URL) {
+        // Only apply protection when the device is unlocked (isProtectedDataAvailable).
+        // Once tightened, the file remains protected; a future (locked) launch sees the
+        // complete protection from disk.
+        guard UIApplication.shared.isProtectedDataAvailable else {
+            return
+        }
+
+        let fileManager = FileManager.default
+        let files = [
+            url.appendingPathExtension("sqlite"),
+            url.appendingPathExtension("sqlite-wal"),
+            url.appendingPathExtension("sqlite-shm"),
+        ]
+
+        for file in files {
+            do {
+                try fileManager.setAttributes(
+                    [.protectionKey: FileProtectionType.complete],
+                    ofItemAtPath: file.path
+                )
+            } catch {
+                // Silently skip file-not-found errors (e.g., -wal/-shm may not exist yet).
+                // Log other errors but never throw — app start must never be blocked.
+                if (error as NSError).code != NSFileNoSuchFileError {
+                    print("Warning: could not harden store file at \(file.lastPathComponent): \(error)")
+                }
+            }
+        }
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AppContainer.swift
@@ -16,7 +16,7 @@ enum AppContainer {
 
     /// Check if a container creation error occurred and return a user-facing message.
     static var containerErrorMessage: String? {
-        guard let error = containerCreationError else { return nil }
+        guard containerCreationError != nil else { return nil }
         return "Unable to access your data. Please restart the app or reinstall if the issue persists."
     }
 
@@ -48,9 +48,7 @@ enum AppContainer {
 
             // Harden the store file protection so the SQLite database is unreadable
             // while the device is locked. Must be called after container creation.
-            if let storeURL = modelConfiguration.url {
-                hardenStore(at: storeURL)
-            }
+            hardenStore(at: modelConfiguration.url)
 
             return container
         } catch {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
@@ -12,6 +12,7 @@ struct AuthenticationWrapper: View {
 
     @State private var isPINSetup: Bool = UserDefaults.standard.bool(forKey: "pin_setup_complete")
     @State private var showSplash = true
+    @State private var isCaptured = UIScreen.main.isCaptured
     // Owned here (not by MainTabView) since AuthenticationWrapper is never torn down
     // while the app is running — MainTabView is recreated on every lock/unlock cycle,
     // which would otherwise reset hideAmounts whenever the app is merely backgrounded.
@@ -53,7 +54,8 @@ struct AuthenticationWrapper: View {
 
             // ponytail: covers the task-switcher snapshot, which is taken on
             // .inactive (before .background triggers the PIN lock below).
-            if scenePhase != .active && !showSplash {
+            // Also covers screen recording / AirPlay mirroring via UIScreen.isCaptured.
+            if (scenePhase != .active || isCaptured) && !showSplash {
                 SplashView()
                     .transition(.opacity)
                     .zIndex(1)
@@ -78,6 +80,9 @@ struct AuthenticationWrapper: View {
         .onReceive(NotificationCenter.default.publisher(for: .pinSetupComplete)) { _ in
             isPINSetup = true
             authService.unlock()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)) { _ in
+            isCaptured = UIScreen.main.isCaptured
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background && isPINSetup {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
@@ -85,7 +85,14 @@ struct AuthenticationWrapper: View {
                 withAnimation(.easeInOut(duration: 0.3)) {
                     showSplash = false
                 }
-                if isPINSetup && authService.isBiometricFeatureEnabled {
+                // `!isUnlocked` matters: the scenePhase→.active trigger below usually
+                // fires first and can have finished a successful Face ID well before
+                // this 0.8s timer runs. PR #20's isAuthenticating guard only suppresses
+                // an *overlapping* second call, so once that first evaluation has
+                // completed this timer opened a second prompt on an already-unlocked
+                // app — the duplicate cold-launch prompt. Matches the condition the
+                // scenePhase trigger already uses.
+                if isPINSetup && authService.isBiometricFeatureEnabled && !authService.isUnlocked {
                     authService.authenticate { _ in }
                 }
             }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/AuthenticationWrapper.swift
@@ -12,6 +12,10 @@ struct AuthenticationWrapper: View {
 
     @State private var isPINSetup: Bool = UserDefaults.standard.bool(forKey: "pin_setup_complete")
     @State private var showSplash = true
+    // ponytail: UIScreen.main is deprecated on iOS 26 in favor of a per-window-scene
+    // lookup; keeping it since this view has no window/scene context to source one
+    // from, and it's a deprecation warning, not a functional gap. Upgrade if/when
+    // this view gains access to a WindowScene (e.g. via @Environment).
     @State private var isCaptured = UIScreen.main.isCaptured
     // Owned here (not by MainTabView) since AuthenticationWrapper is never torn down
     // while the app is running — MainTabView is recreated on every lock/unlock cycle,
@@ -65,7 +69,16 @@ struct AuthenticationWrapper: View {
         .animation(.easeInOut(duration: 0.25), value: authService.isUnlocked)
         .animation(.easeInOut(duration: 0.25), value: scenePhase)
         .onAppear {
-            if !isPINSetup {
+            // ponytail: unit tests run inside this app as their host process, so this
+            // view's real onAppear fires alongside the test bundle. Without this guard,
+            // a fresh test-host launch (isPINSetup false, since the host process has no
+            // PIN set up) clears the SAME Keychain accounts PINServiceTests/
+            // PINEntryViewModelTests write to, at a moment no test-side lock can see —
+            // this was the actual cause of two long-flaky PIN tests, not a concurrency
+            // bug in PINService itself. Standard XCTest-host detection; skip the
+            // production side effect during test runs.
+            let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            if !isPINSetup && !isRunningTests {
                 try? pinService.clearPIN()
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
@@ -27,12 +27,27 @@ struct PersonalFinanceTrakerApp: App {
 
     /// Shared model container for SwiftData persistence
     var sharedModelContainer: ModelContainer = AppContainer.shared
-    
+
+    /// Alert state for container creation errors
+    @State private var containerErrorMessage: String?
+
     // MARK: - Body
-    
+
     var body: some Scene {
         WindowGroup {
             AuthenticationWrapper(modelContainer: sharedModelContainer)
+                .alert("Data Access Error", isPresented: .constant(containerErrorMessage != nil)) {
+                    Button("OK") {
+                        containerErrorMessage = nil
+                    }
+                } message: {
+                    if let message = containerErrorMessage {
+                        Text(message)
+                    }
+                }
+                .onAppear {
+                    containerErrorMessage = AppContainer.containerErrorMessage
+                }
         }
         .modelContainer(sharedModelContainer)
     }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -148,6 +148,8 @@ struct ProfileView: View {
                                     do {
                                         try await RestoreService.restoreLatest(repo: transactionViewModel.repo, backupService: backupService)
                                         dataChanged.bump()
+                                    } catch BackupService.BackupError.decryptionFailed {
+                                        restoreErrorMessage = "Backup can't be decrypted. Make sure iCloud Keychain is enabled on this device."
                                     } catch {
                                         restoreErrorMessage = error.localizedDescription
                                     }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINEntryView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINEntryView.swift
@@ -36,6 +36,8 @@ struct PINEntryView: View {
                 onDigit: { viewModel.appendDigit($0) },
                 onDelete: { viewModel.deleteDigit() }
             )
+            .disabled(viewModel.isLockedOut)
+            .opacity(viewModel.isLockedOut ? 0.5 : 1.0)
 
             VStack(spacing: 16) {
                 if viewModel.showBiometricButton {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINEntryView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/PINEntryView.swift
@@ -38,6 +38,7 @@ struct PINEntryView: View {
             )
             .disabled(viewModel.isLockedOut)
             .opacity(viewModel.isLockedOut ? 0.5 : 1.0)
+            .onAppear { viewModel.refreshLockoutState() }
 
             VStack(spacing: 16) {
                 if viewModel.showBiometricButton {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
@@ -38,7 +38,7 @@ final class PINConfirmationViewModel {
             errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
-        case .lockedOut(let deadline):
+        case .lockedOut:
             errorMessage = "Account locked. Try again later."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINConfirmationViewModel.swift
@@ -30,10 +30,16 @@ final class PINConfirmationViewModel {
     }
 
     private func verifyPIN() {
-        if pinService.validatePIN(pinInput) {
+        let result = pinService.validatePINWithResult(pinInput)
+        switch result {
+        case .success:
             onConfirmed()
-        } else {
-            errorMessage = "Incorrect PIN. Try again."
+        case .failure(let remainingAttempts):
+            errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
+            triggerShake()
+            Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
+        case .lockedOut(let deadline):
+            errorMessage = "Account locked. Try again later."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
         }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
@@ -34,6 +34,28 @@ final class PINEntryViewModel {
         self.authService = authService
     }
 
+    /// Re-syncs the UI to the lockout state persisted in the Keychain.
+    /// Called on every appearance because the lockout survives a force-quit but the
+    /// view model doesn't: on a cold launch mid-lockout, nothing had consulted
+    /// `pinService.lockoutDeadline`, so the pad rendered enabled with no countdown
+    /// until the user burned another 4 digits and got `.lockedOut` back from
+    /// `verifyPIN`. The lockout was always *enforced* (validatePINWithResult
+    /// short-circuits before hashing) — this only restores the matching UI.
+    func refreshLockoutState() {
+        if let deadline = pinService.lockoutDeadline {
+            startLockoutCountdown(until: deadline)
+        } else if isLockedOut {
+            // Deadline elapsed while this view model wasn't running its countdown.
+            countdownTask?.cancel()
+            countdownTask = nil
+            isLockedOut = false
+            lockoutMessage = ""
+            errorMessage = ""
+            pinInput = ""
+            eyesOpen = true
+        }
+    }
+
     func appendDigit(_ digit: String) {
         guard !isLockedOut else { return }
         guard pinInput.count < 4 else { return }
@@ -82,6 +104,11 @@ final class PINEntryViewModel {
     private func startLockoutCountdown(until deadline: Date) {
         countdownTask?.cancel()
         isLockedOut = true
+        // Paint the first message synchronously. The Task below only gets to run on a
+        // later tick, which would otherwise leave the pad disabled with no explanation
+        // for a frame — most visible on a cold launch mid-lockout, where the countdown
+        // is the only thing telling the user why nothing responds.
+        updateLockoutMessage(until: deadline)
 
         countdownTask = Task {
             while !Task.isCancelled {
@@ -97,9 +124,7 @@ final class PINEntryViewModel {
                     break
                 }
 
-                let remainingSeconds = Int(deadline.timeIntervalSince(now)) + 1
-                lockoutMessage = "Locked out. Try again in \(remainingSeconds)s."
-                errorMessage = lockoutMessage
+                updateLockoutMessage(until: deadline)
 
                 do {
                     try await Task.sleep(for: .milliseconds(500))
@@ -108,6 +133,12 @@ final class PINEntryViewModel {
                 }
             }
         }
+    }
+
+    private func updateLockoutMessage(until deadline: Date) {
+        let remainingSeconds = max(1, Int(deadline.timeIntervalSince(Date())) + 1)
+        lockoutMessage = "Locked out. Try again in \(remainingSeconds)s."
+        errorMessage = lockoutMessage
     }
 
     private func triggerShake() {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
@@ -8,9 +8,12 @@ final class PINEntryViewModel {
     var eyesOpen: Bool = true
     var errorMessage: String = ""
     var showForgotPINSheet: Bool = false
+    var isLockedOut: Bool = false
+    var lockoutMessage: String = ""
 
     private let pinService: PINService
     let authService: BiometricAuthService
+    private var countdownTask: Task<Void, Never>?
 
     var showBiometricButton: Bool {
         authService.isBiometricFeatureEnabled && authService.isBiometricsAvailable
@@ -27,6 +30,7 @@ final class PINEntryViewModel {
     }
 
     func appendDigit(_ digit: String) {
+        guard !isLockedOut else { return }
         guard pinInput.count < 4 else { return }
         pinInput += digit
         eyesOpen = false
@@ -55,17 +59,56 @@ final class PINEntryViewModel {
     }
 
     private func verifyPIN() {
-        if pinService.validatePIN(pinInput) {
+        let result = pinService.validatePINWithResult(pinInput)
+        switch result {
+        case .success:
             authService.unlock()
-        } else {
-            errorMessage = "Incorrect PIN. Try again."
+        case .failure(let remainingAttempts):
+            errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
+        case .lockedOut(let deadline):
+            startLockoutCountdown(until: deadline)
+        }
+    }
+
+    private func startLockoutCountdown(until deadline: Date) {
+        countdownTask?.cancel()
+        isLockedOut = true
+
+        countdownTask = Task {
+            while !Task.isCancelled {
+                let now = Date()
+                if now >= deadline {
+                    // Lockout expired
+                    isLockedOut = false
+                    lockoutMessage = ""
+                    errorMessage = ""
+                    pinInput = ""
+                    eyesOpen = true
+                    countdownTask = nil
+                    break
+                }
+
+                let remainingSeconds = Int(deadline.timeIntervalSince(now)) + 1
+                lockoutMessage = "Locked out. Try again in \(remainingSeconds)s."
+                errorMessage = lockoutMessage
+
+                do {
+                    try await Task.sleep(for: .milliseconds(500))
+                } catch {
+                    break
+                }
+            }
         }
     }
 
     private func triggerShake() {
         isShaking = true
         Task { try? await Task.sleep(for: .seconds(0.5)); self.isShaking = false }
+    }
+
+    deinit {
+        countdownTask?.cancel()
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINEntryViewModel.swift
@@ -13,7 +13,12 @@ final class PINEntryViewModel {
 
     private let pinService: PINService
     let authService: BiometricAuthService
-    private var countdownTask: Task<Void, Never>?
+    // nonisolated(unsafe): Task<Void, Never> is Sendable and Task.cancel() is
+    // thread-safe, so this is a safe escape hatch — deinit is always nonisolated
+    // even on a @MainActor class, and plain `nonisolated` isn't accepted here
+    // because @Observable's macro expansion requires mutable stored properties
+    // to stay actor-isolated.
+    private nonisolated(unsafe) var countdownTask: Task<Void, Never>?
 
     var showBiometricButton: Bool {
         authService.isBiometricFeatureEnabled && authService.isBiometricsAvailable
@@ -63,6 +68,8 @@ final class PINEntryViewModel {
         switch result {
         case .success:
             authService.unlock()
+            pinInput = ""
+            eyesOpen = true
         case .failure(let remainingAttempts):
             errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
             triggerShake()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
@@ -105,7 +105,7 @@ final class PINSetupViewModel {
     }
 
     private func advanceToConfirm() {
-        if isChangeMode && pinService.validatePIN(pinInput) {
+        if isChangeMode && pinService.verifyPINForPolicyCheck(pinInput) {
             errorMessage = "New PIN must be different from the current one."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
@@ -97,7 +97,7 @@ final class PINSetupViewModel {
             errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
-        case .lockedOut(let deadline):
+        case .lockedOut:
             errorMessage = "Account locked. Try again later."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Security/ViewModels/PINSetupViewModel.swift
@@ -86,13 +86,19 @@ final class PINSetupViewModel {
     }
 
     private func verifyCurrentPIN() {
-        if pinService.validatePIN(pinInput) {
+        let result = pinService.validatePINWithResult(pinInput)
+        switch result {
+        case .success:
             pinInput = ""
             eyesOpen = true
             errorMessage = ""
             withAnimation { currentStep = .enterPin }
-        } else {
-            errorMessage = "Incorrect PIN. Try again."
+        case .failure(let remainingAttempts):
+            errorMessage = "Incorrect PIN. \(remainingAttempts) attempt\(remainingAttempts == 1 ? "" : "s") remaining."
+            triggerShake()
+            Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
+        case .lockedOut(let deadline):
+            errorMessage = "Account locked. Try again later."
             triggerShake()
             Task { try? await Task.sleep(for: .seconds(0.45)); self.pinInput = ""; self.eyesOpen = true }
         }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Info.plist
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Authentication is required to unlock your financial data.</string>
 	<key>UIFileSharingEnabled</key>

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Info.plist
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Personal Finance</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Authentication is required to unlock your financial data.</string>
 	<key>UIFileSharingEnabled</key>

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
@@ -2321,6 +2321,9 @@
         }
       }
     },
+    "Data Access Error" : {
+
+    },
     "Date" : {
       "localizations" : {
         "en" : {
@@ -6676,6 +6679,9 @@
           }
         }
       }
+    },
+    "Unlock your phone to add a transaction." : {
+
     },
     "Unusually high spending in %@: %@" : {
       "localizations" : {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
@@ -5,6 +5,17 @@ import Security
 enum BackupCrypto {
     private static let backupKeyAccount = "pft.backup_key"
 
+    // ponytail: kSecAttrSynchronizable requires the machine running this code to be
+    // signed into iCloud with Keychain sync enabled — never guaranteed for a unit-test
+    // host (CI, a fresh simulator, a Mac not signed into iCloud), so BackupServiceTests
+    // (which exercise this real key()/fetchKey()/storeKey() path, unlike
+    // BackupCryptoTests which pass an explicit key) failed there with .keychainError.
+    // Store/fetch locally-only under the XCTest host so the encryption round-trip is
+    // still exercised without needing real iCloud state; production keeps syncing.
+    private static var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     /// Fetch or create a 256-bit backup encryption key from iCloud Keychain.
     /// Key is stored with synchronization enabled so it syncs to user's other devices.
     static func key() throws -> SymmetricKey {
@@ -68,7 +79,7 @@ enum BackupCrypto {
             kSecAttrAccount: backupKeyAccount,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecAttrSynchronizable: true
+            kSecAttrSynchronizable: isRunningTests ? false : true
         ]
 
         var result: AnyObject?
@@ -94,7 +105,7 @@ enum BackupCrypto {
             kSecAttrAccount: backupKeyAccount,
             kSecValueData: keyData,
             kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
-            kSecAttrSynchronizable: true
+            kSecAttrSynchronizable: isRunningTests ? false : true
         ]
 
         // Delete any existing key first

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
@@ -5,17 +5,6 @@ import Security
 enum BackupCrypto {
     private static let backupKeyAccount = "pft.backup_key"
 
-    // ponytail: kSecAttrSynchronizable requires the machine running this code to be
-    // signed into iCloud with Keychain sync enabled — never guaranteed for a unit-test
-    // host (CI, a fresh simulator, a Mac not signed into iCloud), so BackupServiceTests
-    // (which exercise this real key()/fetchKey()/storeKey() path, unlike
-    // BackupCryptoTests which pass an explicit key) failed there with .keychainError.
-    // Store/fetch locally-only under the XCTest host so the encryption round-trip is
-    // still exercised without needing real iCloud state; production keeps syncing.
-    private static var isRunningTests: Bool {
-        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-    }
-
     /// Fetch or create a 256-bit backup encryption key from iCloud Keychain.
     /// Key is stored with synchronization enabled so it syncs to user's other devices.
     static func key() throws -> SymmetricKey {
@@ -79,7 +68,7 @@ enum BackupCrypto {
             kSecAttrAccount: backupKeyAccount,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecAttrSynchronizable: isRunningTests ? false : true
+            kSecAttrSynchronizable: true
         ]
 
         var result: AnyObject?
@@ -105,7 +94,7 @@ enum BackupCrypto {
             kSecAttrAccount: backupKeyAccount,
             kSecValueData: keyData,
             kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
-            kSecAttrSynchronizable: isRunningTests ? false : true
+            kSecAttrSynchronizable: true
         ]
 
         // Delete any existing key first

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupCrypto.swift
@@ -1,0 +1,109 @@
+import Foundation
+import CryptoKit
+import Security
+
+enum BackupCrypto {
+    private static let backupKeyAccount = "pft.backup_key"
+
+    /// Fetch or create a 256-bit backup encryption key from iCloud Keychain.
+    /// Key is stored with synchronization enabled so it syncs to user's other devices.
+    static func key() throws -> SymmetricKey {
+        if let existingKey = try fetchKey() {
+            return existingKey
+        }
+
+        let newKey = SymmetricKey(size: .bits256)
+        try storeKey(newKey)
+        return newKey
+    }
+
+    /// Encrypt data using AES-GCM with the backup key.
+    /// Returns the combined sealed box (nonce + ciphertext + tag) as Data.
+    static func seal(_ data: Data) throws -> Data {
+        let key = try Self.key()
+        return try seal(data, using: key)
+    }
+
+    /// Decrypt data using AES-GCM with the backup key.
+    /// Throws `BackupError.decryptionFailed` if the key is wrong or data is tampered.
+    static func open(_ data: Data) throws -> Data {
+        let key = try Self.key()
+        return try open(data, using: key)
+    }
+
+    // MARK: - Internal overloads for testing (accessible via @testable)
+
+    /// Encrypt data using AES-GCM with an explicit key (for testing).
+    static func seal(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let sealedBox = try AES.GCM.seal(data, using: key)
+        guard let combined = sealedBox.combined else {
+            throw BackupService.BackupError.sealingFailed
+        }
+        return combined
+    }
+
+    /// Decrypt data using AES-GCM with an explicit key (for testing).
+    static func open(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let sealedBox: AES.GCM.SealedBox
+        do {
+            sealedBox = try AES.GCM.SealedBox(combined: data)
+        } catch {
+            // Malformed ciphertext (not even parseable)
+            throw BackupService.BackupError.decryptionFailed
+        }
+
+        do {
+            return try AES.GCM.open(sealedBox, using: key)
+        } catch {
+            // Well-formed ciphertext but authentication failed (wrong key or tampering)
+            throw BackupService.BackupError.decryptionFailed
+        }
+    }
+
+    // MARK: - Private Keychain helpers
+
+    private static func fetchKey() throws -> SymmetricKey? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: backupKeyAccount,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecAttrSynchronizable: true
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess {
+            guard let keyData = result as? Data else {
+                throw BackupService.BackupError.keychainError
+            }
+            return SymmetricKey(data: keyData)
+        } else if status == errSecItemNotFound {
+            return nil
+        } else {
+            throw BackupService.BackupError.keychainError
+        }
+    }
+
+    private static func storeKey(_ key: SymmetricKey) throws {
+        let keyData = key.withUnsafeBytes { Data($0) }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: backupKeyAccount,
+            kSecValueData: keyData,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+            kSecAttrSynchronizable: true
+        ]
+
+        // Delete any existing key first
+        SecItemDelete(query as CFDictionary)
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw BackupService.BackupError.keychainError
+        }
+    }
+}
+

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupService.swift
@@ -4,6 +4,9 @@ final class BackupService {
     enum BackupError: Error, Equatable {
         case iCloudUnavailable
         case emptyStore
+        case decryptionFailed
+        case sealingFailed
+        case keychainError
     }
 
     private let storage: BackupStorage
@@ -22,14 +25,24 @@ final class BackupService {
         try FileManager.default.createDirectory(at: containerURL, withIntermediateDirectories: true)
 
         let payload = BackupPayload(
-            version: 1,
+            version: 2,
             createdAt: now,
             transactions: BackupMapper.makeTransactions(from: transactions),
             recurrenceRules: BackupMapper.makeRecurrenceRules(from: recurrenceRules)
         )
         let data = try Self.encoder.encode(payload)
+
+        // Encrypt the payload
+        let encryptedData = try BackupCrypto.seal(data)
+
         let fileURL = containerURL.appendingPathComponent(Self.filename(for: now))
-        try data.write(to: fileURL, options: .atomic)
+        try encryptedData.write(to: fileURL, options: .atomic)
+
+        // Set file protection to complete
+        try FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.complete],
+            ofItemAtPath: fileURL.path
+        )
 
         pruneOldBackups(in: containerURL)
         return fileURL
@@ -38,8 +51,11 @@ final class BackupService {
     func listBackups() -> [URL] {
         guard let containerURL = storage.containerURL() else { return [] }
         let files = (try? FileManager.default.contentsOfDirectory(at: containerURL, includingPropertiesForKeys: nil)) ?? []
+        // Accept both .json (legacy) and .pftbackup (encrypted) files.
         // Filenames are ISO-8601-based, so lexicographic descending order is also newest-first.
-        return files.filter { $0.pathExtension == "json" }.sorted { $0.lastPathComponent > $1.lastPathComponent }
+        return files
+            .filter { $0.pathExtension == "json" || $0.pathExtension == "pftbackup" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
     }
 
     func newestBackup() -> URL? {
@@ -48,6 +64,27 @@ final class BackupService {
 
     func readBackup(at url: URL) throws -> BackupPayload {
         let data = try Data(contentsOf: url)
+
+        // Try to decrypt if it's an encrypted backup (.pftbackup extension)
+        if url.pathExtension == "pftbackup" {
+            do {
+                let decryptedData = try BackupCrypto.open(data)
+                let payload = try Self.decoder.decode(BackupPayload.self, from: decryptedData)
+                // Validate version for encrypted backups
+                guard payload.version >= 2 else {
+                    throw BackupError.decryptionFailed
+                }
+                return payload
+            } catch BackupError.decryptionFailed {
+                // Re-throw decryption failures with the specific error
+                throw BackupError.decryptionFailed
+            } catch {
+                // If decoding fails after successful decryption, it's a data corruption issue
+                throw error
+            }
+        }
+
+        // Legacy plaintext JSON backup (.json extension) — decode directly
         return try Self.decoder.decode(BackupPayload.self, from: data)
     }
 
@@ -63,7 +100,7 @@ final class BackupService {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         let safe = formatter.string(from: date).replacingOccurrences(of: ":", with: "-")
-        return "backup-\(safe).json"
+        return "backup-\(safe).pftbackup"
     }
 
     private static let encoder: JSONEncoder = {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/BackupService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 final class BackupService {
     enum BackupError: Error, Equatable {
@@ -11,10 +12,26 @@ final class BackupService {
 
     private let storage: BackupStorage
     private let maxBackupsKept: Int
+    private let keyProvider: () throws -> SymmetricKey
 
-    init(storage: BackupStorage = FileManagerBackupStorage(), maxBackupsKept: Int = 3) {
+    // ponytail: keyProvider defaults to the real (Keychain-backed, iCloud-synced) key
+    // so production is unchanged. Tests inject a single fixed in-memory key per
+    // BackupService instance instead — BackupCrypto.key()'s Keychain account is
+    // process-global, so two BackupServiceTests/RestoreServiceTests running
+    // concurrently (Swift Testing parallelizes by default) raced on it: both saw "no
+    // key yet", both minted their own, and whichever SecItemAdd lost decrypted with a
+    // key that was no longer what the other test had just overwritten. Passed
+    // locally where less true parallelism happened to hide it; failed reliably on
+    // Xcode Cloud's build. Injecting the key sidesteps shared Keychain state
+    // entirely rather than papering over it with serialization.
+    init(
+        storage: BackupStorage = FileManagerBackupStorage(),
+        maxBackupsKept: Int = 3,
+        keyProvider: @escaping () throws -> SymmetricKey = BackupCrypto.key
+    ) {
         self.storage = storage
         self.maxBackupsKept = maxBackupsKept
+        self.keyProvider = keyProvider
     }
 
     @discardableResult
@@ -33,7 +50,8 @@ final class BackupService {
         let data = try Self.encoder.encode(payload)
 
         // Encrypt the payload
-        let encryptedData = try BackupCrypto.seal(data)
+        let key = try keyProvider()
+        let encryptedData = try BackupCrypto.seal(data, using: key)
 
         let fileURL = containerURL.appendingPathComponent(Self.filename(for: now))
         try encryptedData.write(to: fileURL, options: .atomic)
@@ -68,7 +86,8 @@ final class BackupService {
         // Try to decrypt if it's an encrypted backup (.pftbackup extension)
         if url.pathExtension == "pftbackup" {
             do {
-                let decryptedData = try BackupCrypto.open(data)
+                let key = try keyProvider()
+                let decryptedData = try BackupCrypto.open(data, using: key)
                 let payload = try Self.decoder.decode(BackupPayload.self, from: decryptedData)
                 // Validate version for encrypted backups
                 guard payload.version >= 2 else {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
@@ -20,6 +20,22 @@ final class PINService {
     private let pbkdf2Rounds: UInt32 = 210_000
     private let derivedKeyLength: Int = 32
 
+    // ponytail: in-memory mirror of the failure counter and lockout deadline,
+    // keyed by this instance. Confirmed via instrumentation that a value this same
+    // instance just wrote and verified can still read back stale (not merely
+    // "not found" — genuinely outdated) from a *separate* SecItemCopyMatching call
+    // ~200ms later under heavy concurrent Keychain load (this codebase's 393-test
+    // full suite reproduces it reliably; a single human tapping a PIN pad with
+    // 150-450ms UI delays between attempts never generates that load). Since this
+    // instance already durably wrote the value, there's no need to round-trip
+    // through Keychain to learn what it just wrote — consult the cache first and
+    // only fall back to Keychain on a cold instance (fresh launch, cache empty).
+    // Upgrade path: per-test-instance Keychain account namespacing (see storeTestData)
+    // eliminates cross-instance/cross-suite contention entirely, if this ever
+    // resurfaces at a different layer.
+    private var cachedFailureCount: Int?
+    private var cachedLockoutInfo: LockoutInfo??  // outer optional = not loaded yet; inner = no active lockout
+
     func setPIN(_ pin: String) throws {
         var saltBytes = [UInt8](repeating: 0, count: 32)
         guard SecRandomCopyBytes(kSecRandomDefault, saltBytes.count, &saltBytes) == errSecSuccess else {
@@ -71,6 +87,8 @@ final class PINService {
             // Success: reset counter and clear deadline
             try? delete(forKey: failuresKey)
             try? delete(forKey: lockedUntilKey)
+            cachedFailureCount = 0
+            cachedLockoutInfo = .some(nil)
 
             // Lazy migration: if version was legacy, upgrade to PBKDF2
             if isLegacy {
@@ -136,6 +154,8 @@ final class PINService {
         try delete(forKey: versionKey)
         try delete(forKey: failuresKey)
         try delete(forKey: lockedUntilKey)
+        cachedFailureCount = 0
+        cachedLockoutInfo = .some(nil)
     }
 
     // MARK: - PBKDF2 Derivation and Comparison
@@ -187,48 +207,48 @@ final class PINService {
     }
 
     private func checkCurrentLockout() -> Date? {
+        if let cached = cachedLockoutInfo {
+            return resolveLockout(cached)
+        }
+
         guard let lockoutData = fetch(forKey: lockedUntilKey) else {
+            cachedLockoutInfo = .some(nil)
             return nil
         }
 
-        do {
-            let lockoutInfo = try JSONDecoder().decode(LockoutInfo.self, from: lockoutData)
-            let currentUptime = ProcessInfo.processInfo.systemUptime
-            let storedUptime = lockoutInfo.uptimeAtSet
-
-            // ponytail: reboot detection only; does not catch active clock rollback.
-            // Ceiling: detects systemUptime reset (genuine reboot) but not device clock
-            // set backward during runtime. Upgrade path: compare stored uptime delta
-            // (deadline - uptimeAtSet) with current (now - currentUptime) to catch
-            // mid-runtime rollbacks.
-
-            // Detect reboot: if current uptime < stored uptime, a reboot happened
-            // (systemUptime resets near-zero on reboot)
-            if currentUptime < storedUptime {
-                // Reboot detected: fall back to trusting the absolute Date (conservative)
-                if lockoutInfo.deadline > Date() {
-                    return lockoutInfo.deadline
-                } else {
-                    // Deadline has passed; clear the lockout
-                    try? delete(forKey: lockedUntilKey)
-                    try? delete(forKey: failuresKey)
-                    return nil
-                }
-            }
-
-            // No reboot: Date comparison alone; assumes device clock doesn't roll backward
-            if lockoutInfo.deadline > Date() {
-                return lockoutInfo.deadline
-            } else {
-                // Deadline has passed; clear the lockout
-                try? delete(forKey: lockedUntilKey)
-                try? delete(forKey: failuresKey)
-                return nil
-            }
-        } catch {
-            // Malformed or missing data; fail safe and clear
+        guard let lockoutInfo = try? JSONDecoder().decode(LockoutInfo.self, from: lockoutData) else {
+            // Malformed or missing data; fail safe and clear both — a corrupt
+            // deadline record carries no trustworthy failure count either.
             try? delete(forKey: lockedUntilKey)
             try? delete(forKey: failuresKey)
+            cachedLockoutInfo = .some(nil)
+            cachedFailureCount = 0
+            return nil
+        }
+
+        cachedLockoutInfo = .some(lockoutInfo)
+        return resolveLockout(lockoutInfo)
+    }
+
+    private func resolveLockout(_ lockoutInfo: LockoutInfo?) -> Date? {
+        guard let lockoutInfo else { return nil }
+
+        // ponytail: uptimeAtSet stays on LockoutInfo for the clock-rollback guard's
+        // original design intent, but the reboot-vs-no-reboot branches this used to
+        // have both reduced to the same `deadline > Date()` check, so they were
+        // merged into one. Ceiling: doesn't catch an active mid-runtime clock
+        // rollback (only the absolute Date is trusted). Upgrade path: compare
+        // (deadline - uptimeAtSet) against (now - currentUptime) if that scenario
+        // needs covering.
+        if lockoutInfo.deadline > Date() {
+            return lockoutInfo.deadline
+        } else {
+            // Deadline has passed; clear only the deadline. The failure count
+            // must survive so a repeat offender keeps climbing the escalation
+            // ladder instead of restarting at tier 0 every time a window
+            // elapses — only a successful PIN clears the counter.
+            try? delete(forKey: lockedUntilKey)
+            cachedLockoutInfo = .some(nil)
             return nil
         }
     }
@@ -239,32 +259,39 @@ final class PINService {
             deadline: deadline,
             uptimeAtSet: ProcessInfo.processInfo.systemUptime
         )
+        cachedLockoutInfo = .some(lockoutInfo)
         do {
             let encoded = try JSONEncoder().encode(lockoutInfo)
             try store(data: encoded, forKey: lockedUntilKey)
         } catch {
-            // Encoding/storing lockout should not fail in normal operation.
-            // If it does, fail-safe: lockout deadline is forgotten on next app launch.
-            // Assert in debug to catch unexpected failures during development.
-            assertionFailure("Failed to persist lockout deadline: \(error)")
+            // store() already retries internally (see its ponytail comment) — if it
+            // still throws here, persisting genuinely failed. A crash here is worse
+            // than the fail-safe it's guarding: don't trap. The cache still holds the
+            // deadline for this process's lifetime; only a relaunch loses it.
         }
         return deadline
     }
 
     private func getFailureCount() -> Int {
+        if let cached = cachedFailureCount {
+            return cached
+        }
         // ponytail: counter stored as UTF-8 string, not Codable struct.
         // Ceiling: works for 0-8 attempts; upgrade path is Codable for type-safety
         // and schema versioning if counter logic becomes more complex.
         guard let data = fetch(forKey: failuresKey),
               let count = Int(String(data: data, encoding: .utf8) ?? "") else {
+            cachedFailureCount = 0
             return 0
         }
+        cachedFailureCount = count
         return count
     }
 
     private func incrementFailureCounter() {
         let currentCount = getFailureCount()
         let newCount = currentCount + 1
+        cachedFailureCount = newCount
         if let encoded = String(newCount).data(using: .utf8) {
             try? store(data: encoded, forKey: failuresKey)
         }
@@ -273,24 +300,95 @@ final class PINService {
     // MARK: - Test Helpers (internal for @testable)
 
     func storeTestData(_ data: Data, forKey key: String) throws {
+        // Tests seed pft.pin_failures / pft.pin_locked_until directly to drive the
+        // escalation ladder past what validatePIN's lockout short-circuit allows
+        // (see PINServiceTests' escalation tests). Invalidate the matching cache so
+        // the next read goes back to Keychain instead of serving a stale in-memory
+        // value from before the test's direct write.
+        if key == failuresKey {
+            cachedFailureCount = nil
+        } else if key == lockedUntilKey {
+            cachedLockoutInfo = nil
+        }
         try store(data: data, forKey: key)
     }
 
     // MARK: - Private Keychain helpers
 
+    // Atomic upsert: try SecItemUpdate first, fall back to SecItemAdd only when the
+    // item doesn't exist yet. A prior delete-then-add here left a window where a
+    // concurrent writer (another thread hitting the same account) could add its own
+    // item between our delete and our add, turning our add into a spurious
+    // errSecDuplicateItem — the exact crash this codebase hit in practice (see the
+    // PINConfirmationViewModelTests serialization fix). Removing the gap fixes it
+    // at the source.
+    // ponytail: writes here reported success (no throw) but a same-process
+    // SecItemCopyMatching immediately after sometimes still returned
+    // errSecItemNotFound — a read-after-write visibility lag in the Keychain
+    // daemon under heavy concurrent load. Verify-then-retry closes that window
+    // instead of silently trusting a write that hasn't landed yet.
+    // Ceiling: 3 attempts, ~15ms apart — tuned for this failure mode, not a
+    // general-purpose retry policy. Upgrade path: if this still fires in
+    // practice, widen the backoff or attempt count.
     private func store(data: Data, forKey key: String) throws {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: key,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            kSecValueData: data
-        ]
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else { throw PINServiceError.keychainError(status: status) }
+        var lastError: Error?
+        for _ in 0..<3 {
+            do {
+                try writeOnce(data: data, forKey: key)
+                if fetchOnce(forKey: key) == data {
+                    return
+                }
+            } catch {
+                lastError = error
+            }
+            Thread.sleep(forTimeInterval: 0.015)
+        }
+        if let lastError {
+            throw lastError
+        }
+        // All attempts reported success but never verified — surface it rather
+        // than silently pretending the write landed.
+        throw PINServiceError.keychainError(status: errSecItemNotFound)
     }
 
+    private func writeOnce(data: Data, forKey key: String) throws {
+        let matchQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        let updateStatus = SecItemUpdate(matchQuery as CFDictionary, [kSecValueData: data] as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            throw PINServiceError.keychainError(status: updateStatus)
+        }
+        var addQuery = matchQuery
+        addQuery[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        addQuery[kSecValueData] = data
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else { throw PINServiceError.keychainError(status: addStatus) }
+    }
+
+    // ponytail: a fetch() immediately following a write() that itself just verified
+    // the same key can still come back "not found" a few ms later under heavy
+    // concurrent load. One retry after a short sleep resolves that specific window.
+    // This does not cover a later read seeing stale-but-present data — that's what
+    // the in-memory cache above exists to sidestep.
     private func fetch(forKey key: String) -> Data? {
+        if let data = fetchOnce(forKey: key) {
+            return data
+        }
+        for _ in 0..<2 {
+            Thread.sleep(forTimeInterval: 0.015)
+            if let data = fetchOnce(forKey: key) {
+                return data
+            }
+        }
+        return nil
+    }
+
+    private func fetchOnce(forKey key: String) -> Data? {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
@@ -318,4 +416,3 @@ enum PINServiceError: Error {
 extension Notification.Name {
     static let pinSetupComplete = Notification.Name("com.pft.pinSetupComplete")
 }
-

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
@@ -2,9 +2,19 @@ import Foundation
 import CryptoKit
 import Security
 
+enum PINValidationResult: Equatable {
+    case success
+    case failure(remainingAttempts: Int)
+    case lockedOut(until: Date)
+}
+
 final class PINService {
     private let hashKey = "pft.pin_hash"
     private let saltKey = "pft.pin_salt"
+    private let failuresKey = "pft.pin_failures"
+    private let lockedUntilKey = "pft.pin_locked_until"
+
+    private let escalationTiers: [Int] = [60, 300, 900, 3600] // 1, 5, 15, 60 minutes in seconds
 
     func setPIN(_ pin: String) throws {
         var saltBytes = [UInt8](repeating: 0, count: 32)
@@ -18,10 +28,74 @@ final class PINService {
     }
 
     func validatePIN(_ pin: String) -> Bool {
+        // Check for active lockout first (without touching hash or counter)
+        if checkCurrentLockout() != nil {
+            return false
+        }
+
         guard let salt = fetch(forKey: saltKey),
-              let storedHash = fetch(forKey: hashKey) else { return false }
+              let storedHash = fetch(forKey: hashKey) else {
+            return false
+        }
+
         let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
-        return computed == storedHash
+        if computed == storedHash {
+            // Success: reset counter and clear deadline
+            try? delete(forKey: failuresKey)
+            try? delete(forKey: lockedUntilKey)
+            return true
+        } else {
+            // Failure: increment counter (but only if not already locked out)
+            incrementFailureCounter()
+            let failureCount = getFailureCount()
+            if failureCount >= 5 {
+                // Lock out: compute tier from count and set deadline
+                let tier = min(failureCount - 5, escalationTiers.count - 1)
+                let lockoutSeconds = escalationTiers[tier]
+                _ = setLockoutDeadline(lockoutSeconds: lockoutSeconds)
+            }
+            return false
+        }
+    }
+
+    // For Task 3 migration: internal method that returns the detailed result
+    // (Will be renamed to validatePIN in Task 3)
+    func validatePINWithResult(_ pin: String) -> PINValidationResult {
+        // Check for active lockout first (without touching hash or counter)
+        if let lockoutUntil = checkCurrentLockout() {
+            return .lockedOut(until: lockoutUntil)
+        }
+
+        guard let salt = fetch(forKey: saltKey),
+              let storedHash = fetch(forKey: hashKey) else {
+            return .failure(remainingAttempts: 5)
+        }
+
+        let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+        if computed == storedHash {
+            // Success: reset counter and clear deadline
+            try? delete(forKey: failuresKey)
+            try? delete(forKey: lockedUntilKey)
+            return .success
+        } else {
+            // Failure: increment counter and check if we've hit lockout threshold
+            incrementFailureCounter()
+            let failureCount = getFailureCount()
+            if failureCount >= 5 {
+                // Lock out: compute tier from count and set deadline
+                let tier = min(failureCount - 5, escalationTiers.count - 1)
+                let lockoutSeconds = escalationTiers[tier]
+                let deadline = setLockoutDeadline(lockoutSeconds: lockoutSeconds)
+                return .lockedOut(until: deadline)
+            } else {
+                let remainingAttempts = 5 - failureCount
+                return .failure(remainingAttempts: remainingAttempts)
+            }
+        }
+    }
+
+    var lockoutDeadline: Date? {
+        checkCurrentLockout()
     }
 
     func isPINSet() -> Bool { fetch(forKey: hashKey) != nil }
@@ -29,6 +103,86 @@ final class PINService {
     func clearPIN() throws {
         try delete(forKey: hashKey)
         try delete(forKey: saltKey)
+        try delete(forKey: failuresKey)
+        try delete(forKey: lockedUntilKey)
+    }
+
+    // MARK: - Lockout Management
+
+    // Structure to hold lockout deadline + uptime at time of lock (for clock-rollback guard)
+    private struct LockoutInfo: Codable {
+        let deadline: Date
+        let uptimeAtSet: TimeInterval
+    }
+
+    private func checkCurrentLockout() -> Date? {
+        guard let lockoutData = fetch(forKey: lockedUntilKey) else {
+            return nil
+        }
+
+        do {
+            let lockoutInfo = try JSONDecoder().decode(LockoutInfo.self, from: lockoutData)
+            let currentUptime = ProcessInfo.processInfo.systemUptime
+            let storedUptime = lockoutInfo.uptimeAtSet
+
+            // Detect reboot: if current uptime < stored uptime, a reboot happened
+            // (systemUptime resets near-zero on reboot)
+            if currentUptime < storedUptime {
+                // Reboot detected: fall back to trusting the absolute Date (conservative)
+                if lockoutInfo.deadline > Date() {
+                    return lockoutInfo.deadline
+                } else {
+                    // Deadline has passed; clear the lockout
+                    try? delete(forKey: lockedUntilKey)
+                    try? delete(forKey: failuresKey)
+                    return nil
+                }
+            }
+
+            // No reboot: use uptime delta to detect clock rollback
+            // If the deadline is in the future (either by Date or by uptime comparison), we're locked
+            if lockoutInfo.deadline > Date() {
+                return lockoutInfo.deadline
+            } else {
+                // Deadline has passed; clear the lockout
+                try? delete(forKey: lockedUntilKey)
+                try? delete(forKey: failuresKey)
+                return nil
+            }
+        } catch {
+            // Malformed or missing data; fail safe and clear
+            try? delete(forKey: lockedUntilKey)
+            try? delete(forKey: failuresKey)
+            return nil
+        }
+    }
+
+    private func setLockoutDeadline(lockoutSeconds: Int) -> Date {
+        let deadline = Date().addingTimeInterval(TimeInterval(lockoutSeconds))
+        let lockoutInfo = LockoutInfo(
+            deadline: deadline,
+            uptimeAtSet: ProcessInfo.processInfo.systemUptime
+        )
+        if let encoded = try? JSONEncoder().encode(lockoutInfo) {
+            try? store(data: encoded, forKey: lockedUntilKey)
+        }
+        return deadline
+    }
+
+    private func getFailureCount() -> Int {
+        guard let data = fetch(forKey: failuresKey),
+              let count = Int(String(data: data, encoding: .utf8) ?? "") else {
+            return 0
+        }
+        return count
+    }
+
+    private func incrementFailureCounter() {
+        let currentCount = getFailureCount()
+        let newCount = currentCount + 1
+        if let encoded = String(newCount).data(using: .utf8) {
+            try? store(data: encoded, forKey: failuresKey)
+        }
     }
 
     // MARK: - Private Keychain helpers
@@ -73,3 +227,4 @@ enum PINServiceError: Error {
 extension Notification.Name {
     static let pinSetupComplete = Notification.Name("com.pft.pinSetupComplete")
 }
+

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
@@ -125,6 +125,12 @@ final class PINService {
             let currentUptime = ProcessInfo.processInfo.systemUptime
             let storedUptime = lockoutInfo.uptimeAtSet
 
+            // ponytail: reboot detection only; does not catch active clock rollback.
+            // Ceiling: detects systemUptime reset (genuine reboot) but not device clock
+            // set backward during runtime. Upgrade path: compare stored uptime delta
+            // (deadline - uptimeAtSet) with current (now - currentUptime) to catch
+            // mid-runtime rollbacks.
+
             // Detect reboot: if current uptime < stored uptime, a reboot happened
             // (systemUptime resets near-zero on reboot)
             if currentUptime < storedUptime {
@@ -139,8 +145,7 @@ final class PINService {
                 }
             }
 
-            // No reboot: use uptime delta to detect clock rollback
-            // If the deadline is in the future (either by Date or by uptime comparison), we're locked
+            // No reboot: Date comparison alone; assumes device clock doesn't roll backward
             if lockoutInfo.deadline > Date() {
                 return lockoutInfo.deadline
             } else {
@@ -163,13 +168,22 @@ final class PINService {
             deadline: deadline,
             uptimeAtSet: ProcessInfo.processInfo.systemUptime
         )
-        if let encoded = try? JSONEncoder().encode(lockoutInfo) {
-            try? store(data: encoded, forKey: lockedUntilKey)
+        do {
+            let encoded = try JSONEncoder().encode(lockoutInfo)
+            try store(data: encoded, forKey: lockedUntilKey)
+        } catch {
+            // Encoding/storing lockout should not fail in normal operation.
+            // If it does, fail-safe: lockout deadline is forgotten on next app launch.
+            // Assert in debug to catch unexpected failures during development.
+            assertionFailure("Failed to persist lockout deadline: \(error)")
         }
         return deadline
     }
 
     private func getFailureCount() -> Int {
+        // ponytail: counter stored as UTF-8 string, not Codable struct.
+        // Ceiling: works for 0-8 attempts; upgrade path is Codable for type-safety
+        // and schema versioning if counter logic becomes more complex.
         guard let data = fetch(forKey: failuresKey),
               let count = Int(String(data: data, encoding: .utf8) ?? "") else {
             return 0

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CryptoKit
 import Security
+import CommonCrypto
 
 enum PINValidationResult: Equatable {
     case success
@@ -11,10 +12,13 @@ enum PINValidationResult: Equatable {
 final class PINService {
     private let hashKey = "pft.pin_hash"
     private let saltKey = "pft.pin_salt"
+    private let versionKey = "pft.pin_hash_version"
     private let failuresKey = "pft.pin_failures"
     private let lockedUntilKey = "pft.pin_locked_until"
 
     private let escalationTiers: [Int] = [60, 300, 900, 3600] // 1, 5, 15, 60 minutes in seconds
+    private let pbkdf2Rounds: UInt32 = 210_000
+    private let derivedKeyLength: Int = 32
 
     func setPIN(_ pin: String) throws {
         var saltBytes = [UInt8](repeating: 0, count: 32)
@@ -22,40 +26,15 @@ final class PINService {
             throw PINServiceError.keychainError(status: -1)
         }
         let salt = Data(saltBytes)
-        let hashData = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+        let hashData = derivePBKDF2(pin: pin, salt: salt)
         try store(data: salt, forKey: saltKey)
         try store(data: hashData, forKey: hashKey)
+        try store(data: "2".data(using: .utf8)!, forKey: versionKey)
     }
 
     func validatePIN(_ pin: String) -> Bool {
-        // Check for active lockout first (without touching hash or counter)
-        if checkCurrentLockout() != nil {
-            return false
-        }
-
-        guard let salt = fetch(forKey: saltKey),
-              let storedHash = fetch(forKey: hashKey) else {
-            return false
-        }
-
-        let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
-        if computed == storedHash {
-            // Success: reset counter and clear deadline
-            try? delete(forKey: failuresKey)
-            try? delete(forKey: lockedUntilKey)
-            return true
-        } else {
-            // Failure: increment counter (but only if not already locked out)
-            incrementFailureCounter()
-            let failureCount = getFailureCount()
-            if failureCount >= 5 {
-                // Lock out: compute tier from count and set deadline
-                let tier = min(failureCount - 5, escalationTiers.count - 1)
-                let lockoutSeconds = escalationTiers[tier]
-                _ = setLockoutDeadline(lockoutSeconds: lockoutSeconds)
-            }
-            return false
-        }
+        let result = validatePINWithResult(pin)
+        return result == .success
     }
 
     // For Task 3 migration: internal method that returns the detailed result
@@ -71,11 +50,35 @@ final class PINService {
             return .failure(remainingAttempts: 5)
         }
 
-        let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
-        if computed == storedHash {
+        let versionData = fetch(forKey: versionKey)
+        let versionString = versionData.flatMap { String(data: $0, encoding: .utf8) }
+        let isLegacy = versionString != "2"
+
+        let isValid: Bool
+        if isLegacy {
+            // ponytail: legacy SHA-256 verification, beta-only. DELETE before App Store
+            // release — drop this branch, drop `pft.pin_hash_version`, and have setPIN/
+            // validatePIN speak PBKDF2 only. Any straggler on the old format just
+            // re-runs PIN setup.
+            let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+            isValid = constantTimeEqual(computed, storedHash)
+        } else {
+            let computed = derivePBKDF2(pin: pin, salt: salt)
+            isValid = constantTimeEqual(computed, storedHash)
+        }
+
+        if isValid {
             // Success: reset counter and clear deadline
             try? delete(forKey: failuresKey)
             try? delete(forKey: lockedUntilKey)
+
+            // Lazy migration: if version was legacy, upgrade to PBKDF2
+            if isLegacy {
+                let pbkdf2Hash = derivePBKDF2(pin: pin, salt: salt)
+                try? store(data: pbkdf2Hash, forKey: hashKey)
+                try? store(data: "2".data(using: .utf8)!, forKey: versionKey)
+            }
+
             return .success
         } else {
             // Failure: increment counter and check if we've hit lockout threshold
@@ -103,8 +106,49 @@ final class PINService {
     func clearPIN() throws {
         try delete(forKey: hashKey)
         try delete(forKey: saltKey)
+        try delete(forKey: versionKey)
         try delete(forKey: failuresKey)
         try delete(forKey: lockedUntilKey)
+    }
+
+    // MARK: - PBKDF2 Derivation and Comparison
+
+    private func derivePBKDF2(pin: String, salt: Data) -> Data {
+        guard let pinBytes = pin.data(using: .utf8) else {
+            return Data()
+        }
+
+        var derivedKey = [UInt8](repeating: 0, count: derivedKeyLength)
+        let saltBytes = [UInt8](salt)
+
+        let status = CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm(kCCPBKDF2),
+            (pin as NSString).utf8String, pinBytes.count,
+            saltBytes, saltBytes.count,
+            CCPseudoRandomAlgorithm(kCCHmacAlgSHA256),
+            pbkdf2Rounds,
+            &derivedKey,
+            derivedKey.count
+        )
+
+        guard status == kCCSuccess else {
+            return Data()
+        }
+
+        return Data(derivedKey)
+    }
+
+    private func constantTimeEqual(_ a: Data, _ b: Data) -> Bool {
+        guard a.count == b.count else {
+            return false
+        }
+
+        var result: UInt8 = 0
+        for i in 0..<a.count {
+            result |= a[i] ^ b[i]
+        }
+
+        return result == 0
     }
 
     // MARK: - Lockout Management
@@ -197,6 +241,12 @@ final class PINService {
         if let encoded = String(newCount).data(using: .utf8) {
             try? store(data: encoded, forKey: failuresKey)
         }
+    }
+
+    // MARK: - Test Helpers (internal for @testable)
+
+    func storeTestData(_ data: Data, forKey key: String) throws {
+        try store(data: data, forKey: key)
     }
 
     // MARK: - Private Keychain helpers

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/PINService.swift
@@ -101,6 +101,33 @@ final class PINService {
         checkCurrentLockout()
     }
 
+    /// Verifies a PIN against the stored hash without counting it as an authentication attempt.
+    /// Used for business-rule checks (e.g., "new PIN must differ from current PIN") that should
+    /// never trigger the failure counter or lockout, only for policy validation.
+    /// - Parameter pin: The PIN to verify
+    /// - Returns: true if the PIN matches the stored hash, false otherwise
+    func verifyPINForPolicyCheck(_ pin: String) -> Bool {
+        guard let salt = fetch(forKey: saltKey),
+              let storedHash = fetch(forKey: hashKey) else {
+            return false
+        }
+
+        let versionData = fetch(forKey: versionKey)
+        let versionString = versionData.flatMap { String(data: $0, encoding: .utf8) }
+        let isLegacy = versionString != "2"
+
+        let isValid: Bool
+        if isLegacy {
+            let computed = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+            isValid = constantTimeEqual(computed, storedHash)
+        } else {
+            let computed = derivePBKDF2(pin: pin, salt: salt)
+            isValid = constantTimeEqual(computed, storedHash)
+        }
+
+        return isValid
+    }
+
     func isPINSet() -> Bool { fetch(forKey: hashKey) != nil }
 
     func clearPIN() throws {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ReminderService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ReminderService.swift
@@ -59,7 +59,6 @@ final class ReminderService {
             let content = UNMutableNotificationContent()
             content.title = "Log today's spending"
             content.body = "Take 30 seconds to record what you spent today."
-            content.interruptionLevel = .sensitive
             let comps = Calendar.current.dateComponents(
                 [.year, .month, .day, .hour, .minute], from: date
             )

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ReminderService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ReminderService.swift
@@ -59,6 +59,7 @@ final class ReminderService {
             let content = UNMutableNotificationContent()
             content.title = "Log today's spending"
             content.body = "Take 30 seconds to record what you spent today."
+            content.interruptionLevel = .sensitive
             let comps = Calendar.current.dateComponents(
                 [.year, .month, .day, .hour, .minute], from: date
             )

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINConfirmationViewModelTests.swift
@@ -3,6 +3,8 @@ import Foundation
 
 @testable import PersonalFinanceTraker
 
+extension PINKeychainSerialTests {
+
 @Suite(.serialized)
 @MainActor
 struct PINConfirmationViewModelTests {
@@ -117,4 +119,6 @@ struct PINConfirmationViewModelTests {
         #expect(viewModel.pinInput.isEmpty)
         #expect(viewModel.eyesOpen)
     }
+}
+
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
@@ -105,6 +105,60 @@ struct PINEntryViewModelTests {
         #expect(viewModel.errorMessage == viewModel.lockoutMessage)
     }
 
+    @Test("Lockout UI is restored on a cold launch mid-lockout")
+    func refreshLockoutStateRestoresLockoutAfterRelaunch() async throws {
+        await PINTestLock.shared.acquire()
+        defer {
+            try? pinService.clearPIN()
+            Task { await PINTestLock.shared.release() }
+        }
+        try? pinService.clearPIN()
+
+        try pinService.setPIN("1234")
+
+        for _ in 0..<5 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+        #expect(pinService.lockoutDeadline != nil)
+
+        // A brand-new view model stands in for the one built on a fresh launch:
+        // it has never seen a .lockedOut result, so its state starts clean.
+        let authService = BiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+        #expect(viewModel.isLockedOut == false)
+
+        viewModel.refreshLockoutState()
+
+        #expect(viewModel.isLockedOut)
+        #expect(viewModel.lockoutMessage.contains("Locked out"))
+        #expect(viewModel.errorMessage == viewModel.lockoutMessage)
+
+        // And the pad stays inert without spending an attempt.
+        viewModel.appendDigit("1")
+        #expect(viewModel.pinInput.isEmpty)
+    }
+
+    @Test("refreshLockoutState leaves an unlocked view model alone")
+    func refreshLockoutStateNoOpsWhenNotLockedOut() async throws {
+        await PINTestLock.shared.acquire()
+        defer {
+            try? pinService.clearPIN()
+            Task { await PINTestLock.shared.release() }
+        }
+        try? pinService.clearPIN()
+
+        try pinService.setPIN("1234")
+
+        let authService = BiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        viewModel.refreshLockoutState()
+
+        #expect(viewModel.isLockedOut == false)
+        #expect(viewModel.lockoutMessage.isEmpty)
+        #expect(viewModel.errorMessage.isEmpty)
+    }
+
     @Test("Incorrect PIN shows remaining attempts")
     func incorrectPINShowsRemainingAttempts() async throws {
         defer { try? pinService.clearPIN() }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
@@ -1,0 +1,185 @@
+import Testing
+import Foundation
+
+@testable import PersonalFinanceTraker
+
+private final class FakeBiometricAuthService: BiometricAuthService {
+    var isBiometricFeatureEnabled: Bool = true
+    var isBiometricsAvailable: Bool = true
+
+    func authenticate(completion: @escaping (Bool) -> Void) {
+        completion(true)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct PINEntryViewModelTests {
+    private let pinService = PINService()
+
+    @Test("Correct PIN entered digit-by-digit unlocks the app")
+    func correctPINUnlocks() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        #expect(viewModel.isLockedOut == false)
+        #expect(viewModel.errorMessage.isEmpty)
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+        viewModel.appendDigit("4")
+
+        #expect(viewModel.pinInput == "1234")
+
+        // Wait for verifyPIN async validation to complete
+        try await Task.sleep(for: .seconds(0.3))
+
+        // Success should have cleared the input
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.errorMessage.isEmpty)
+        #expect(viewModel.isLockedOut == false)
+    }
+
+    @Test("appendDigit no-ops while locked out")
+    func appendDigitNoOpsWhileLockedOut() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        // Trigger 5 failures to lock out
+        for _ in 0..<5 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        #expect(pinService.lockoutDeadline != nil)
+
+        // Manually set lockout on viewModel
+        viewModel.isLockedOut = true
+
+        // appendDigit should no-op
+        viewModel.appendDigit("1")
+        #expect(viewModel.pinInput.isEmpty)
+
+        viewModel.appendDigit("2")
+        #expect(viewModel.pinInput.isEmpty)
+    }
+
+    @Test("Lockout message displays when PIN entry results in lockout")
+    func lockoutMessageDisplays() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        // Trigger 5 failures in pinService to lock out
+        for _ in 0..<5 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        #expect(pinService.lockoutDeadline != nil)
+
+        // Now try to enter more digits on the locked-out viewModel
+        // This should trigger verifyPIN with a locked-out result
+        viewModel.appendDigit("5")
+        viewModel.appendDigit("6")
+        viewModel.appendDigit("7")
+        viewModel.appendDigit("8")
+
+        #expect(viewModel.pinInput == "5678")
+
+        // Wait for verifyPIN to execute (0.15s delay + processing)
+        try await Task.sleep(for: .seconds(0.3))
+
+        // Now locked out - check that lockoutMessage is populated
+        #expect(viewModel.isLockedOut)
+        #expect(!viewModel.lockoutMessage.isEmpty)
+        #expect(viewModel.lockoutMessage.contains("Locked out"))
+        #expect(viewModel.errorMessage == viewModel.lockoutMessage)
+    }
+
+    @Test("Incorrect PIN shows remaining attempts")
+    func incorrectPINShowsRemainingAttempts() async throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        viewModel.appendDigit("5")
+        viewModel.appendDigit("6")
+        viewModel.appendDigit("7")
+        viewModel.appendDigit("8")
+
+        #expect(viewModel.pinInput == "5678")
+
+        try await Task.sleep(for: .seconds(0.3))
+
+        #expect(viewModel.errorMessage.contains("4 attempts"))
+        #expect(viewModel.isShaking)
+
+        // Reset fires after shake delay
+        try await Task.sleep(for: .seconds(0.5))
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+    }
+
+    @Test("appendDigit does not append beyond 4 digits")
+    func appendDigitBoundary() {
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+        viewModel.appendDigit("4")
+        viewModel.appendDigit("5")
+
+        #expect(viewModel.pinInput == "1234")
+        #expect(viewModel.pinInput.count == 4)
+    }
+
+    @Test("deleteDigit removes last digit and updates eyesOpen")
+    func deleteDigit() {
+        let authService = FakeBiometricAuthService()
+        let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
+
+        viewModel.appendDigit("1")
+        viewModel.appendDigit("2")
+        viewModel.appendDigit("3")
+
+        #expect(viewModel.pinInput == "123")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput == "12")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput == "1")
+        #expect(!viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+
+        viewModel.deleteDigit()
+
+        #expect(viewModel.pinInput.isEmpty)
+        #expect(viewModel.eyesOpen)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINEntryViewModelTests.swift
@@ -3,14 +3,7 @@ import Foundation
 
 @testable import PersonalFinanceTraker
 
-private final class FakeBiometricAuthService: BiometricAuthService {
-    var isBiometricFeatureEnabled: Bool = true
-    var isBiometricsAvailable: Bool = true
-
-    func authenticate(completion: @escaping (Bool) -> Void) {
-        completion(true)
-    }
-}
+extension PINKeychainSerialTests {
 
 @MainActor
 @Suite(.serialized)
@@ -19,11 +12,15 @@ struct PINEntryViewModelTests {
 
     @Test("Correct PIN entered digit-by-digit unlocks the app")
     func correctPINUnlocks() async throws {
-        defer { try? pinService.clearPIN() }
+        await PINTestLock.shared.acquire()
+        defer {
+            try? pinService.clearPIN()
+            Task { await PINTestLock.shared.release() }
+        }
 
         try pinService.setPIN("1234")
 
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         #expect(viewModel.isLockedOut == false)
@@ -36,8 +33,9 @@ struct PINEntryViewModelTests {
 
         #expect(viewModel.pinInput == "1234")
 
-        // Wait for verifyPIN async validation to complete
-        try await Task.sleep(for: .seconds(0.3))
+        // Wait for verifyPIN async validation to complete. Generous margin —
+        // under full-suite CPU contention 0.3s wasn't always enough.
+        try await Task.sleep(for: .seconds(1.0))
 
         // Success should have cleared the input
         #expect(viewModel.pinInput.isEmpty)
@@ -51,7 +49,7 @@ struct PINEntryViewModelTests {
 
         try pinService.setPIN("1234")
 
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         // Trigger 5 failures to lock out
@@ -78,7 +76,7 @@ struct PINEntryViewModelTests {
 
         try pinService.setPIN("1234")
 
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         // Trigger 5 failures in pinService to lock out
@@ -113,7 +111,7 @@ struct PINEntryViewModelTests {
 
         try pinService.setPIN("1234")
 
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         viewModel.appendDigit("5")
@@ -137,7 +135,7 @@ struct PINEntryViewModelTests {
 
     @Test("appendDigit does not append beyond 4 digits")
     func appendDigitBoundary() {
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         viewModel.appendDigit("1")
@@ -152,7 +150,7 @@ struct PINEntryViewModelTests {
 
     @Test("deleteDigit removes last digit and updates eyesOpen")
     func deleteDigit() {
-        let authService = FakeBiometricAuthService()
+        let authService = BiometricAuthService()
         let viewModel = PINEntryViewModel(pinService: pinService, authService: authService)
 
         viewModel.appendDigit("1")
@@ -182,4 +180,6 @@ struct PINEntryViewModelTests {
         #expect(viewModel.pinInput.isEmpty)
         #expect(viewModel.eyesOpen)
     }
+}
+
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINKeychainSerialTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINKeychainSerialTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+// ponytail: PINServiceTests, PINEntryViewModelTests, PINSetupViewModelTests, and
+// PINConfirmationViewModelTests all share the same global Keychain accounts
+// (pft.pin_hash, pft.pin_failures, pft.pin_locked_until, ...). Each suite already
+// serializes its own tests via @Suite(.serialized), but Swift Testing still runs
+// separate suites concurrently — nothing stopped suite A's `clearPIN()` teardown
+// from wiping suite B's in-flight state. Nesting all four as children of this
+// suite makes .serialized cascade across all of them (documented, recursive
+// behavior), so only one PIN test runs at a time process-wide.
+// Upgrade path: give PINService an injectable Keychain account prefix so each
+// test/suite gets its own namespace and this shared-suite trick becomes unneeded.
+@Suite(.serialized)
+struct PINKeychainSerialTests {}
+
+// ponytail: belt-and-suspenders lock for the two tests that stayed flaky under the
+// full 393-test run even after the nesting above and an atomic-upsert fix to
+// PINService.store() — isolated runs of just these suites always passed, so
+// something in the full run still touches Keychain state these tests read/write
+// (BackupCryptoTests, DataWipeServiceTests, etc. — different accounts, same
+// underlying keychain database). Rather than guess at another framework-level
+// lever, this guards exactly the two affected tests directly. Upgrade path: same
+// as PINService's injectable-account-prefix note above — remove this once that
+// lands and Keychain state is test-instance-scoped.
+actor PINTestLock {
+    static let shared = PINTestLock()
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        guard isLocked else {
+            isLocked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            isLocked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
@@ -321,6 +321,72 @@ struct PINServiceTests {
         }
     }
 
+    // MARK: - Policy Check (Non-Counting Validation)
+
+    @Test("verifyPINForPolicyCheck matches correct PIN without counting attempt")
+    func policyCheckCorrectPIN() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Policy check should succeed without side effects
+        #expect(pinService.verifyPINForPolicyCheck("1234") == true)
+
+        // Failure counter should not have incremented
+        let result = pinService.validatePINWithResult("0000")
+        if case .failure(let remaining) = result {
+            #expect(remaining == 4) // Not 3, confirming no prior increment
+        } else {
+            Issue.record("Expected .failure(remainingAttempts: 4)")
+        }
+    }
+
+    @Test("verifyPINForPolicyCheck rejects wrong PIN without counting attempt")
+    func policyCheckWrongPIN() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Policy check should fail without side effects
+        #expect(pinService.verifyPINForPolicyCheck("0000") == false)
+
+        // Failure counter should not have incremented
+        let result = pinService.validatePINWithResult("0000")
+        if case .failure(let remaining) = result {
+            #expect(remaining == 4) // Not 3, confirming no prior increment
+        } else {
+            Issue.record("Expected .failure(remainingAttempts: 4)")
+        }
+    }
+
+    @Test("verifyPINForPolicyCheck does not affect lockout state")
+    func policyCheckDoesNotDriveLockout() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 4 failures via normal validation path
+        for _ in 0..<4 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        // Policy check many times with wrong PIN - should not increment counter
+        for _ in 0..<10 {
+            #expect(pinService.verifyPINForPolicyCheck("0000") == false)
+        }
+
+        // Counter should still be at 4, not locked out
+        #expect(pinService.lockoutDeadline == nil)
+
+        // One more validation failure via normal path should lock out
+        let result = pinService.validatePINWithResult("0000")
+        if case .lockedOut = result {
+            // Expected: 5th failure triggers lockout
+        } else {
+            Issue.record("Expected .lockedOut after 5th validation failure")
+        }
+    }
+
     // MARK: - Edge Cases
 
     @Test("PIN can be cleared after lockout")

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
@@ -1,5 +1,7 @@
 import Testing
 import Foundation
+import CryptoKit
+import Security
 
 @testable import PersonalFinanceTraker
 
@@ -352,5 +354,126 @@ struct PINServiceTests {
 
         try pinService.setPIN("1234")
         #expect(pinService.isPINSet() == true)
+    }
+
+    // MARK: - PBKDF2 and Lazy Migration Tests
+
+    @Test("New PIN uses PBKDF2 from the start")
+    func newPINUsesPBKDF2() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Validate with correct PIN should succeed
+        let result = pinService.validatePINWithResult("1234")
+        #expect(result == .success)
+
+        // Validate with wrong PIN should fail
+        let wrongResult = pinService.validatePINWithResult("0000")
+        if case .failure(let remaining) = wrongResult {
+            #expect(remaining == 4)
+        } else {
+            Issue.record("Expected .failure for wrong PIN")
+        }
+    }
+
+    @Test("Legacy SHA-256 PIN validates successfully and upgrades to PBKDF2")
+    func legacySHA256ValidationAndUpgrade() throws {
+        defer { try? pinService.clearPIN() }
+
+        // Manually create a legacy SHA-256 PIN by directly storing it
+        // without going through the new setPIN() method
+        let pin = "1234"
+        var saltBytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, saltBytes.count, &saltBytes) == errSecSuccess else {
+            Issue.record("Failed to generate random salt")
+            return
+        }
+        let salt = Data(saltBytes)
+
+        // Use the old SHA-256 formula: hash(pin + salt.base64EncodedString())
+        let legacyHashData = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+
+        // Store salt and legacy hash (no version marker = legacy)
+        try pinService.storeTestData(salt, forKey: "pft.pin_salt")
+        try pinService.storeTestData(legacyHashData, forKey: "pft.pin_hash")
+
+        // Validate with correct PIN - should succeed and trigger migration
+        let result = pinService.validatePINWithResult("1234")
+        #expect(result == .success)
+
+        // Verify that subsequent validation still works (confirming upgrade was stored)
+        let secondResult = pinService.validatePINWithResult("1234")
+        #expect(secondResult == .success)
+    }
+
+    @Test("Wrong PIN against PBKDF2 hash fails and drives lockout counter")
+    func wrongPBKDF2PINDrivesLockout() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // First failure against PBKDF2 hash
+        var result = pinService.validatePINWithResult("0000")
+        if case .failure(let remaining) = result {
+            #expect(remaining == 4)
+        } else {
+            Issue.record("Expected .failure(remainingAttempts: 4)")
+            return
+        }
+
+        // Continue failing to trigger lockout at 5 failures
+        for _ in 0..<4 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        // 5th failure should trigger lockout
+        result = pinService.validatePINWithResult("0000")
+        if case .lockedOut = result {
+            // Expected
+        } else {
+            Issue.record("Expected .lockedOut after 5 failures against PBKDF2 hash")
+        }
+    }
+
+    @Test("Legacy PIN failure also drives lockout counter (before upgrade)")
+    func legacyPINFailureDrivesLockout() throws {
+        defer { try? pinService.clearPIN() }
+
+        let pin = "1234"
+        var saltBytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, saltBytes.count, &saltBytes) == errSecSuccess else {
+            Issue.record("Failed to generate random salt")
+            return
+        }
+        let salt = Data(saltBytes)
+
+        // Create legacy SHA-256 PIN
+        let legacyHashData = Data(SHA256.hash(data: Data((pin + salt.base64EncodedString()).utf8)))
+
+        try pinService.storeTestData(salt, forKey: "pft.pin_salt")
+        try pinService.storeTestData(legacyHashData, forKey: "pft.pin_hash")
+
+        // First failure with wrong PIN
+        var result = pinService.validatePINWithResult("0000")
+        if case .failure(let remaining) = result {
+            #expect(remaining == 4)
+        } else {
+            Issue.record("Expected .failure(remainingAttempts: 4)")
+            return
+        }
+
+        // Continue failing to trigger lockout
+        for _ in 0..<4 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        // 5th failure should trigger lockout (even on legacy format)
+        result = pinService.validatePINWithResult("0000")
+        if case .lockedOut = result {
+            // Expected
+        } else {
+            Issue.record("Expected .lockedOut after 5 failures on legacy PIN format")
+        }
     }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
@@ -5,6 +5,8 @@ import Security
 
 @testable import PersonalFinanceTraker
 
+extension PINKeychainSerialTests {
+
 @Suite(.serialized)
 struct PINServiceTests {
     private let pinService = PINService()
@@ -17,8 +19,17 @@ struct PINServiceTests {
     // MARK: - Lockout Triggering
 
     @Test("Lockout triggers at 5 consecutive failures")
-    func lockoutTriggersAtFiveFailures() throws {
-        defer { try? pinService.clearPIN() }
+    func lockoutTriggersAtFiveFailures() async throws {
+        await PINTestLock.shared.acquire()
+        defer {
+            try? pinService.clearPIN()
+            Task { await PINTestLock.shared.release() }
+        }
+        // init() already ran (and cleared PIN state) before acquire() above could
+        // block — a concurrent test holding the lock could have set fresh state
+        // between that init-time clear and this point. Clear again now that the
+        // lock is actually held, so the slate really is clean.
+        try? pinService.clearPIN()
 
         try pinService.setPIN("1234")
 
@@ -86,10 +97,14 @@ struct PINServiceTests {
 
         try pinService.setPIN("1234")
 
-        // Trigger 6 failures (increments through 5, then one more before next tier)
-        for _ in 0..<6 {
-            _ = pinService.validatePIN("0000")
-        }
+        // Seed 5 prior failures directly: the 6th real attempt below is what pushes
+        // the tier from 1-min to 5-min. Looping validatePIN 6 times doesn't work
+        // here — the 5th failure already triggers a lockout, and every attempt
+        // after that short-circuits in checkCurrentLockout() before the counter
+        // increments, so a real user's next attempt only arrives once that window
+        // has passed (simulated by seeding the counter, not the lockout deadline).
+        try pinService.storeTestData(Data("5".utf8), forKey: "pft.pin_failures")
+        _ = pinService.validatePIN("0000")
 
         guard let deadline = pinService.lockoutDeadline else {
             Issue.record("Expected lockout deadline after 6 failures")
@@ -108,10 +123,10 @@ struct PINServiceTests {
 
         try pinService.setPIN("1234")
 
-        // Trigger 7 failures
-        for _ in 0..<7 {
-            _ = pinService.validatePIN("0000")
-        }
+        // Seed 6 prior failures directly — see escalation5MinuteTier for why looping
+        // validatePIN doesn't reach this count on its own.
+        try pinService.storeTestData(Data("6".utf8), forKey: "pft.pin_failures")
+        _ = pinService.validatePIN("0000")
 
         guard let deadline = pinService.lockoutDeadline else {
             Issue.record("Expected lockout deadline after 7 failures")
@@ -130,10 +145,10 @@ struct PINServiceTests {
 
         try pinService.setPIN("1234")
 
-        // Trigger 8 failures
-        for _ in 0..<8 {
-            _ = pinService.validatePIN("0000")
-        }
+        // Seed 7 prior failures directly — see escalation5MinuteTier for why looping
+        // validatePIN doesn't reach this count on its own.
+        try pinService.storeTestData(Data("7".utf8), forKey: "pft.pin_failures")
+        _ = pinService.validatePIN("0000")
 
         guard let deadline8 = pinService.lockoutDeadline else {
             Issue.record("Expected lockout deadline after 8 failures")
@@ -145,22 +160,24 @@ struct PINServiceTests {
         // 60 minutes = 3600 seconds; allow ~5s margin for test execution
         #expect(lockoutSeconds8 > 3595 && lockoutSeconds8 <= 3605)
 
-        // Try 9 failures - tier should remain 60 min (capped)
-        // Simulate: clear lockout first to continue testing, then trigger 9th
+        // 9th failure - tier should remain 60 min (capped), not climb further.
+        // The 8th failure above is still actively locked out, so clear everything
+        // and re-seed rather than validating straight through — same reasoning as
+        // escalation5MinuteTier: an active lockout short-circuits before the
+        // counter would increment.
         try? pinService.clearPIN()
         try pinService.setPIN("1234")
-        for _ in 0..<9 {
-            _ = pinService.validatePIN("0000")
-        }
+        try pinService.storeTestData(Data("8".utf8), forKey: "pft.pin_failures")
+        _ = pinService.validatePIN("0000")
 
         guard let deadline9 = pinService.lockoutDeadline else {
             Issue.record("Expected lockout deadline after 9 failures")
             return
         }
 
-        let lockoutSeconds9 = deadline9.timeIntervalSince(now)
-        // Should also be around 60 minutes (capped) - allow wider margin since time has passed
-        #expect(lockoutSeconds9 > 3590 && lockoutSeconds9 <= 3610)
+        let lockoutSeconds9 = deadline9.timeIntervalSince(Date())
+        // Should also be around 60 minutes (capped)
+        #expect(lockoutSeconds9 > 3595 && lockoutSeconds9 <= 3605)
     }
 
     // MARK: - Success Resets Counter and Deadline
@@ -229,7 +246,7 @@ struct PINServiceTests {
     // MARK: - Clock Rollback Guard
 
     @Test("Clock rollback guard preserves lockout across reboot simulation")
-    func clockRollbackGuardHoldsLockout() throws {
+    func clockRollbackGuardHoldsLockout() async throws {
         defer { try? pinService.clearPIN() }
 
         try pinService.setPIN("1234")
@@ -542,4 +559,6 @@ struct PINServiceTests {
             Issue.record("Expected .lockedOut after 5 failures on legacy PIN format")
         }
     }
+}
+
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
@@ -197,19 +197,31 @@ struct PINServiceTests {
 
         try pinService.setPIN("1234")
 
-        // Trigger lockout (5 failures)
-        for _ in 0..<5 {
-            _ = pinService.validatePIN("0000")
+        // Trigger 4 failures (sub-threshold)
+        for _ in 0..<4 {
+            _ = pinService.validatePINWithResult("0000")
         }
+        #expect(pinService.lockoutDeadline == nil)
 
+        // Validate correct PIN → success
+        var result = pinService.validatePINWithResult("1234")
+        #expect(result == .success)
+        #expect(pinService.lockoutDeadline == nil)
+
+        // Trigger 5 failures to lock out
+        for _ in 0..<5 {
+            _ = pinService.validatePINWithResult("0000")
+        }
         #expect(pinService.lockoutDeadline != nil)
 
-        // Wait a brief moment to ensure deadline is in future, then success
-        try await Task.sleep(for: .milliseconds(10))
-
-        // Note: lockout prevents the correct PIN from being validated,
-        // so we can't test success during lockout with the Bool API.
-        // This will be better tested via validatePINWithResult() in integration tests.
+        // Attempt correct PIN while locked — should be rejected immediately
+        // without hash check or counter increment (short-circuit)
+        result = pinService.validatePINWithResult("1234")
+        if case .lockedOut = result {
+            // Expected: lockout prevents any validation
+        } else {
+            Issue.record("Expected .lockedOut while in lockout, got \(result)")
+        }
     }
 
     // MARK: - Clock Rollback Guard

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINServiceTests.swift
@@ -1,0 +1,344 @@
+import Testing
+import Foundation
+
+@testable import PersonalFinanceTraker
+
+@Suite(.serialized)
+struct PINServiceTests {
+    private let pinService = PINService()
+
+    init() {
+        // Clean up before suite
+        try? pinService.clearPIN()
+    }
+
+    // MARK: - Lockout Triggering
+
+    @Test("Lockout triggers at 5 consecutive failures")
+    func lockoutTriggersAtFiveFailures() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // First 4 failures should not lock out
+        for _ in 0..<4 {
+            #expect(pinService.validatePIN("0000") == false)
+            #expect(pinService.lockoutDeadline == nil)
+        }
+
+        // 5th failure should lock out
+        #expect(pinService.validatePIN("0000") == false)
+        #expect(pinService.lockoutDeadline != nil)
+    }
+
+    @Test("Lockout immediately rejects further attempts")
+    func lockoutRejectsAttemptsImmediately() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger lockout (5 failures)
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        let deadlineAfterLockout = pinService.lockoutDeadline
+        #expect(deadlineAfterLockout != nil)
+
+        // Attempt to validate during lockout - should return false
+        // without incrementing counter further (short-circuit)
+        #expect(pinService.validatePIN("0000") == false)
+
+        // Deadline should not have changed (short-circuit prevents counter increment)
+        let deadlineAfterRejectedAttempt = pinService.lockoutDeadline
+        #expect(deadlineAfterRejectedAttempt == deadlineAfterLockout)
+    }
+
+    // MARK: - Escalation Tiers
+
+    @Test("Escalation hits 1-min tier at 5 failures")
+    func escalationMinuteTier() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 5 failures
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let deadline = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 5 failures")
+            return
+        }
+
+        let now = Date()
+        let lockoutSeconds = deadline.timeIntervalSince(now)
+        // 1 minute = 60 seconds; allow ~5s margin for test execution
+        #expect(lockoutSeconds > 55 && lockoutSeconds <= 65)
+    }
+
+    @Test("Escalation hits 5-min tier at 6 failures")
+    func escalation5MinuteTier() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 6 failures (increments through 5, then one more before next tier)
+        for _ in 0..<6 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let deadline = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 6 failures")
+            return
+        }
+
+        let now = Date()
+        let lockoutSeconds = deadline.timeIntervalSince(now)
+        // 5 minutes = 300 seconds; allow ~5s margin for test execution
+        #expect(lockoutSeconds > 295 && lockoutSeconds <= 305)
+    }
+
+    @Test("Escalation hits 15-min tier at 7 failures")
+    func escalation15MinuteTier() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 7 failures
+        for _ in 0..<7 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let deadline = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 7 failures")
+            return
+        }
+
+        let now = Date()
+        let lockoutSeconds = deadline.timeIntervalSince(now)
+        // 15 minutes = 900 seconds; allow ~5s margin for test execution
+        #expect(lockoutSeconds > 895 && lockoutSeconds <= 905)
+    }
+
+    @Test("Escalation hits 60-min tier at 8 failures and caps")
+    func escalation60MinuteTierCapped() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 8 failures
+        for _ in 0..<8 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let deadline8 = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 8 failures")
+            return
+        }
+
+        let now = Date()
+        let lockoutSeconds8 = deadline8.timeIntervalSince(now)
+        // 60 minutes = 3600 seconds; allow ~5s margin for test execution
+        #expect(lockoutSeconds8 > 3595 && lockoutSeconds8 <= 3605)
+
+        // Try 9 failures - tier should remain 60 min (capped)
+        // Simulate: clear lockout first to continue testing, then trigger 9th
+        try? pinService.clearPIN()
+        try pinService.setPIN("1234")
+        for _ in 0..<9 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let deadline9 = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 9 failures")
+            return
+        }
+
+        let lockoutSeconds9 = deadline9.timeIntervalSince(now)
+        // Should also be around 60 minutes (capped) - allow wider margin since time has passed
+        #expect(lockoutSeconds9 > 3590 && lockoutSeconds9 <= 3610)
+    }
+
+    // MARK: - Success Resets Counter and Deadline
+
+    @Test("Successful validation resets counter and clears deadline")
+    func successResetsCounterAndDeadline() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger 3 failures (below threshold)
+        for _ in 0..<3 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        #expect(pinService.lockoutDeadline == nil)
+
+        // Successful validation
+        #expect(pinService.validatePIN("1234") == true)
+
+        // Counter and deadline should be clear
+        #expect(pinService.lockoutDeadline == nil)
+
+        // Next 5 failures should start fresh, not pick up from 3
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        // After fresh 5 failures, should be locked out
+        #expect(pinService.lockoutDeadline != nil)
+    }
+
+    @Test("Success during lockout clears both counter and deadline")
+    func successDuringLockoutClearsAll() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger lockout (5 failures)
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        #expect(pinService.lockoutDeadline != nil)
+
+        // Wait a brief moment to ensure deadline is in future, then success
+        try await Task.sleep(for: .milliseconds(10))
+
+        // Note: lockout prevents the correct PIN from being validated,
+        // so we can't test success during lockout with the Bool API.
+        // This will be better tested via validatePINWithResult() in integration tests.
+    }
+
+    // MARK: - Clock Rollback Guard
+
+    @Test("Clock rollback guard preserves lockout across reboot simulation")
+    func clockRollbackGuardHoldsLockout() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger lockout (5 failures)
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        guard let originalDeadline = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline after 5 failures")
+            return
+        }
+
+        // Verify the deadline is stored correctly (it persists via Keychain)
+        // The next read should return approximately the same deadline
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let readBackDeadline = pinService.lockoutDeadline else {
+            Issue.record("Expected lockout deadline to persist")
+            return
+        }
+
+        // Deadline should remain approximately the same (within ~1s)
+        let timeDiff = abs(readBackDeadline.timeIntervalSince(originalDeadline))
+        #expect(timeDiff < 1.0)
+    }
+
+    // MARK: - validatePINWithResult (internal method for Task 2/3 testing)
+
+    @Test("validatePINWithResult returns .success on correct PIN")
+    func validatePINWithResultSuccess() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        let result = pinService.validatePINWithResult("1234")
+        #expect(result == .success)
+    }
+
+    @Test("validatePINWithResult returns .failure with remaining attempts")
+    func validatePINWithResultFailure() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // First failure: 4 attempts remaining
+        var result = pinService.validatePINWithResult("0000")
+        #expect(result == .failure(remainingAttempts: 4))
+
+        // Second failure: 3 attempts remaining
+        result = pinService.validatePINWithResult("0000")
+        #expect(result == .failure(remainingAttempts: 3))
+
+        // Third failure: 2 attempts remaining
+        result = pinService.validatePINWithResult("0000")
+        #expect(result == .failure(remainingAttempts: 2))
+
+        // Fourth failure: 1 attempt remaining
+        result = pinService.validatePINWithResult("0000")
+        #expect(result == .failure(remainingAttempts: 1))
+
+        // Fifth failure: locked out
+        result = pinService.validatePINWithResult("0000")
+        if case .lockedOut = result {
+            // Expected
+        } else {
+            Issue.record("Expected .lockedOut after 5 failures, got \(result)")
+        }
+    }
+
+    @Test("validatePINWithResult returns .lockedOut during lockout")
+    func validatePINWithResultLockedOut() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+
+        // Trigger lockout (5 failures)
+        for _ in 0..<5 {
+            _ = pinService.validatePINWithResult("0000")
+        }
+
+        // Attempt during lockout
+        let result = pinService.validatePINWithResult("0000")
+        if case .lockedOut(let until) = result {
+            #expect(until > Date())
+        } else {
+            Issue.record("Expected .lockedOut during lockout, got \(result)")
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("PIN can be cleared after lockout")
+    func clearPINAfterLockout() throws {
+        try pinService.setPIN("1234")
+
+        // Trigger lockout
+        for _ in 0..<5 {
+            _ = pinService.validatePIN("0000")
+        }
+
+        #expect(pinService.lockoutDeadline != nil)
+
+        // Clear should remove both PIN and lockout state
+        try pinService.clearPIN()
+
+        #expect(pinService.isPINSet() == false)
+        #expect(pinService.lockoutDeadline == nil)
+    }
+
+    @Test("isPINSet returns false before PIN is set")
+    func isPINSetBeforeSet() {
+        defer { try? pinService.clearPIN() }
+
+        #expect(pinService.isPINSet() == false)
+    }
+
+    @Test("isPINSet returns true after PIN is set")
+    func isPINSetAfterSet() throws {
+        defer { try? pinService.clearPIN() }
+
+        try pinService.setPIN("1234")
+        #expect(pinService.isPINSet() == true)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINSetupViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/Security/PINSetupViewModelTests.swift
@@ -18,6 +18,8 @@ private final class FakeBiometricAuthService: BiometricAuthenticating {
     }
 }
 
+extension PINKeychainSerialTests {
+
 @MainActor
 @Suite(.serialized)
 struct PINSetupViewModelTests {
@@ -220,4 +222,6 @@ struct PINSetupViewModelTests {
         #expect(viewModel.currentStep == .success)
         #expect(UserDefaults.standard.bool(forKey: "pin_setup_complete"))
     }
+}
+
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupCryptoTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupCryptoTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+import CryptoKit
+@testable import PersonalFinanceTraker
+
+struct BackupCryptoTests {
+    @Test func sealAndOpenRoundTrip() throws {
+        let originalData = "Hello, World!".data(using: .utf8)!
+        let key = SymmetricKey(size: .bits256)
+
+        let sealed = try BackupCrypto.seal(originalData, using: key)
+        let decrypted = try BackupCrypto.open(sealed, using: key)
+
+        #expect(decrypted == originalData)
+    }
+
+    @Test func openThrowsWithWrongKey() throws {
+        let originalData = "Hello, World!".data(using: .utf8)!
+        let key1 = SymmetricKey(size: .bits256)
+        let key2 = SymmetricKey(size: .bits256)
+
+        let sealed = try BackupCrypto.seal(originalData, using: key1)
+
+        #expect(throws: BackupService.BackupError.decryptionFailed) {
+            try BackupCrypto.open(sealed, using: key2)
+        }
+    }
+
+    @Test func openThrowsWithTamperedCiphertext() throws {
+        let originalData = "Hello, World!".data(using: .utf8)!
+        let key = SymmetricKey(size: .bits256)
+
+        var sealed = try BackupCrypto.seal(originalData, using: key)
+
+        // Tamper with a byte in the middle of the ciphertext
+        if sealed.count > 20 {
+            sealed[sealed.count / 2] ^= 0xFF
+        }
+
+        #expect(throws: BackupService.BackupError.decryptionFailed) {
+            try BackupCrypto.open(sealed, using: key)
+        }
+    }
+
+    @Test func openThrowsWithMalformedCiphertext() throws {
+        let key = SymmetricKey(size: .bits256)
+        let malformed = "not a valid sealed box".data(using: .utf8)!
+
+        #expect(throws: BackupService.BackupError.decryptionFailed) {
+            try BackupCrypto.open(malformed, using: key)
+        }
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupSchedulerTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupSchedulerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import PersonalFinanceTraker
 
 final class TestSchedulingSettings: BackupSchedulingSettings {
@@ -7,14 +8,23 @@ final class TestSchedulingSettings: BackupSchedulingSettings {
 }
 
 struct BackupSchedulerTests {
+    // ponytail: see BackupServiceTests' matching comment — an injected per-instance
+    // key avoids racing on BackupCrypto's process-global Keychain account under
+    // Swift Testing's default parallel execution.
+    private let backupKey = SymmetricKey(size: .bits256)
+
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 9) -> Date {
         Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+    private func makeService(storage: TestBackupStorage, maxBackupsKept: Int = 3) -> BackupService {
+        BackupService(storage: storage, maxBackupsKept: maxBackupsKept, keyProvider: { backupKey })
     }
 
     private func makeTempService() -> BackupService {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return BackupService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
+        return makeService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
     }
 
     @Test func runsBackupWhenNeverBackedUpBefore() async {
@@ -57,7 +67,7 @@ struct BackupSchedulerTests {
         let repo = MockTransactionRepository()
         repo.stubbedTransactions = [.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
         let settings = TestSchedulingSettings()
-        let service = BackupService(storage: TestBackupStorage(url: nil), maxBackupsKept: 3)
+        let service = makeService(storage: TestBackupStorage(url: nil), maxBackupsKept: 3)
 
         await BackupScheduler.runIfNeeded(repo: repo, settings: settings, backupService: service, now: date(2026, 1, 2))
 

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
@@ -1,12 +1,24 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import PersonalFinanceTraker
 
 struct BackupServiceTests {
+    // ponytail: fresh per test invocation (struct is re-instantiated per @Test), so
+    // each test's BackupService gets its own isolated in-memory key instead of
+    // sharing BackupCrypto's process-global Keychain account — see BackupService's
+    // keyProvider doc comment for why that mattered (cross-test Keychain race under
+    // Swift Testing's default parallel execution).
+    private let backupKey = SymmetricKey(size: .bits256)
+
     private func makeTempStorage() -> (storage: TestBackupStorage, url: URL) {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return (TestBackupStorage(url: dir), dir)
+    }
+
+    private func makeService(storage: TestBackupStorage, maxBackupsKept: Int = 3) -> BackupService {
+        BackupService(storage: storage, maxBackupsKept: maxBackupsKept, keyProvider: { backupKey })
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
@@ -15,7 +27,7 @@ struct BackupServiceTests {
 
     @Test func writeBackupCreatesAJSONFileInTheContainer() throws {
         let (storage, dir) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
 
         let url = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 2))
@@ -26,7 +38,7 @@ struct BackupServiceTests {
 
     @Test func writeBackupThrowsWhenTransactionsAreEmpty() {
         let (storage, _) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
 
         #expect(throws: BackupService.BackupError.emptyStore) {
             try service.writeBackup(transactions: [], recurrenceRules: [], now: date(2026, 1, 1))
@@ -35,7 +47,7 @@ struct BackupServiceTests {
 
     @Test func writeBackupThrowsWhenICloudUnavailable() {
         let storage = TestBackupStorage(url: nil)
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
 
         #expect(throws: BackupService.BackupError.iCloudUnavailable) {
@@ -45,7 +57,7 @@ struct BackupServiceTests {
 
     @Test func newestBackupReturnsTheMostRecentlyWrittenFile() throws {
         let (storage, _) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
 
         let first = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 1, 9, 0))
@@ -57,7 +69,7 @@ struct BackupServiceTests {
 
     @Test func writeBackupPrunesBeyondMaxBackupsKept() throws {
         let (storage, _) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 2)
+        let service = makeService(storage: storage, maxBackupsKept: 2)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
 
         _ = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 1, 9, 0))
@@ -69,7 +81,7 @@ struct BackupServiceTests {
 
     @Test func readBackupDecodesWhatWasWritten() throws {
         let (storage, _) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, note: "Lunch", category: "Food")]
 
         let url = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 1))
@@ -81,7 +93,7 @@ struct BackupServiceTests {
 
     @Test func encryptedWriteAndReadRoundTrip() throws {
         let (storage, _) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, note: "Encrypted", category: "Food")]
 
         // Write creates an encrypted .pftbackup file
@@ -97,7 +109,7 @@ struct BackupServiceTests {
 
     @Test func legacyPlaintextJSONBackupStillRestores() throws {
         let (storage, dir) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let service = makeService(storage: storage, maxBackupsKept: 3)
 
         // Create a legacy .json backup by encoding plaintext
         let legacyPayload = BackupPayload(
@@ -134,7 +146,7 @@ struct BackupServiceTests {
 
     @Test func listBackupsIncludesBothJsonAndPftbackupExtensions() throws {
         let (storage, dir) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 10)
+        let service = makeService(storage: storage, maxBackupsKept: 10)
 
         // Create a legacy .json backup
         let legacyPayload = BackupPayload(
@@ -172,7 +184,7 @@ struct BackupServiceTests {
 
     @Test func newestBackupPicksCorrectlyAmongMixedFiles() throws {
         let (storage, dir) = makeTempStorage()
-        let service = BackupService(storage: storage, maxBackupsKept: 10)
+        let service = makeService(storage: storage, maxBackupsKept: 10)
 
         // Create an older encrypted backup
         let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
@@ -78,4 +78,112 @@ struct BackupServiceTests {
         #expect(payload.transactions.count == 1)
         #expect(payload.transactions[0].note == "Lunch")
     }
+
+    @Test func encryptedWriteAndReadRoundTrip() throws {
+        let (storage, _) = makeTempStorage()
+        let service = BackupService(storage: storage, maxBackupsKept: 3)
+        let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, note: "Encrypted", category: "Food")]
+
+        // Write creates an encrypted .pftbackup file
+        let url = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 1))
+        #expect(url.pathExtension == "pftbackup")
+
+        // Read successfully decrypts and decodes
+        let payload = try service.readBackup(at: url)
+        #expect(payload.version == 2)
+        #expect(payload.transactions.count == 1)
+        #expect(payload.transactions[0].note == "Encrypted")
+    }
+
+    @Test func legacyPlaintextJSONBackupStillRestores() throws {
+        let (storage, dir) = makeTempStorage()
+        let service = BackupService(storage: storage, maxBackupsKept: 3)
+
+        // Create a legacy .json backup by encoding plaintext
+        let legacyPayload = BackupPayload(
+            version: 1,
+            createdAt: date(2026, 1, 1),
+            transactions: [
+                BackupTransaction(
+                    timestamp: date(2026, 1, 1),
+                    amount: -50,
+                    note: "Legacy",
+                    category: "Food",
+                    currencyCode: "EUR",
+                    goalId: nil,
+                    recurrenceRuleId: nil
+                )
+            ],
+            recurrenceRules: []
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyData = try encoder.encode(legacyPayload)
+
+        // Write it with .json extension
+        let legacyURL = dir.appendingPathComponent("backup-legacy.json")
+        try legacyData.write(to: legacyURL, options: .atomic)
+
+        // Read should successfully decode the plaintext JSON
+        let readPayload = try service.readBackup(at: legacyURL)
+        #expect(readPayload.version == 1)
+        #expect(readPayload.transactions.count == 1)
+        #expect(readPayload.transactions[0].note == "Legacy")
+    }
+
+    @Test func listBackupsIncludesBothJsonAndPftbackupExtensions() throws {
+        let (storage, dir) = makeTempStorage()
+        let service = BackupService(storage: storage, maxBackupsKept: 10)
+
+        // Create a legacy .json backup
+        let legacyPayload = BackupPayload(
+            version: 1,
+            createdAt: date(2026, 1, 1),
+            transactions: [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")],
+            recurrenceRules: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyData = try encoder.encode(legacyPayload)
+        let legacyURL = dir.appendingPathComponent("backup-2026-01-01T00-00-00Z.json")
+        try legacyData.write(to: legacyURL, options: .atomic)
+
+        // Create an encrypted backup via writeBackup
+        let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 2), amount: -20, category: "Transport")]
+        let encryptedURL = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 2))
+
+        // listBackups should include both
+        let backups = service.listBackups()
+        #expect(backups.count == 2)
+        #expect(backups.contains { $0.pathExtension == "json" })
+        #expect(backups.contains { $0.pathExtension == "pftbackup" })
+    }
+
+    @Test func newestBackupPicksCorrectlyAmongMixedFiles() throws {
+        let (storage, dir) = makeTempStorage()
+        let service = BackupService(storage: storage, maxBackupsKept: 10)
+
+        // Create an older encrypted backup
+        let tx = [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")]
+        let olderEncrypted = try service.writeBackup(transactions: tx, recurrenceRules: [], now: date(2026, 1, 1, 9, 0))
+
+        // Create a newer legacy .json backup
+        let legacyPayload = BackupPayload(
+            version: 1,
+            createdAt: date(2026, 1, 2),
+            transactions: [TransactionSnapshot.test(timestamp: date(2026, 1, 2), amount: -20, category: "Transport")],
+            recurrenceRules: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyData = try encoder.encode(legacyPayload)
+        let newerJson = dir.appendingPathComponent("backup-2026-01-02T09-00-00Z.json")
+        try legacyData.write(to: newerJson, options: .atomic)
+
+        // newestBackup should pick the newer one (regardless of format)
+        let newest = service.newestBackup()
+        #expect(newest == newerJson)
+        #expect(newest != olderEncrypted)
+    }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/BackupServiceTests.swift
@@ -140,7 +140,17 @@ struct BackupServiceTests {
         let legacyPayload = BackupPayload(
             version: 1,
             createdAt: date(2026, 1, 1),
-            transactions: [TransactionSnapshot.test(timestamp: date(2026, 1, 1), amount: -10, category: "Food")],
+            transactions: [
+                BackupTransaction(
+                    timestamp: date(2026, 1, 1),
+                    amount: -10,
+                    note: "",
+                    category: "Food",
+                    currencyCode: "EUR",
+                    goalId: nil,
+                    recurrenceRuleId: nil
+                )
+            ],
             recurrenceRules: []
         )
         let encoder = JSONEncoder()
@@ -172,7 +182,17 @@ struct BackupServiceTests {
         let legacyPayload = BackupPayload(
             version: 1,
             createdAt: date(2026, 1, 2),
-            transactions: [TransactionSnapshot.test(timestamp: date(2026, 1, 2), amount: -20, category: "Transport")],
+            transactions: [
+                BackupTransaction(
+                    timestamp: date(2026, 1, 2),
+                    amount: -20,
+                    note: "",
+                    category: "Transport",
+                    currencyCode: "EUR",
+                    goalId: nil,
+                    recurrenceRuleId: nil
+                )
+            ],
             recurrenceRules: []
         )
         let encoder = JSONEncoder()

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/RestoreServiceTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/RestoreServiceTests.swift
@@ -1,16 +1,26 @@
 import Testing
 import Foundation
+import CryptoKit
 @testable import PersonalFinanceTraker
 
 struct RestoreServiceTests {
+    // ponytail: see BackupServiceTests' matching comment — an injected per-instance
+    // key avoids racing on BackupCrypto's process-global Keychain account under
+    // Swift Testing's default parallel execution.
+    private let backupKey = SymmetricKey(size: .bits256)
+
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
         Calendar.current.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    private func makeService(storage: TestBackupStorage, maxBackupsKept: Int = 3) -> BackupService {
+        BackupService(storage: storage, maxBackupsKept: maxBackupsKept, keyProvider: { backupKey })
     }
 
     @Test func restoreLatestThrowsWhenNoBackupExists() async {
         let repo = MockTransactionRepository()
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let service = BackupService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
+        let service = makeService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
 
         await #expect(throws: RestoreService.RestoreError.noBackupFound) {
             try await RestoreService.restoreLatest(repo: repo, backupService: service)
@@ -20,7 +30,7 @@ struct RestoreServiceTests {
     @Test func restoreLatestWipesThenRestoresFromNewestBackup() async throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let service = BackupService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
+        let service = makeService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
 
         let ruleId = UUID()
         _ = try service.writeBackup(
@@ -44,7 +54,7 @@ struct RestoreServiceTests {
     @Test func restoreLatestRethrowsWhenRepositoryFails() async throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let service = BackupService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
+        let service = makeService(storage: TestBackupStorage(url: dir), maxBackupsKept: 3)
 
         _ = try service.writeBackup(
             transactions: [.test(timestamp: date(2026, 1, 5), amount: -42, note: "Lunch", category: "Food")],


### PR DESCRIPTION
## Summary

Closes the gap where the PIN/Face ID lock protected the UI but not the data itself:

- **PIN lockout** — escalating delays (1/5/15/60 min) after 5 consecutive failures, persisted in Keychain so it survives force-quit. Counter only resets on a successful PIN, not on lockout expiry.
- **PBKDF2 PIN stretching** — 210,000-round PBKDF2-HMAC-SHA256 replacing single-round SHA-256, with lazy migration for existing beta installs (legacy path marked for removal before App Store release).
- **Encrypted backups** — AES-GCM with a 256-bit key in iCloud Keychain; backups are unreadable blobs (`.pftbackup`) instead of plaintext JSON in the Files app. Legacy plaintext backups still restore.
- **Screen-capture guard** — extends the existing task-switcher cover to screen recording / AirPlay mirroring.
- **At-rest store protection** — `FileProtectionType.complete` on the SwiftData store (+ WAL/SHM sidecars) and on backup files, so the on-disk data is unreadable while the device is locked. Graceful fallback (no crash) if container creation fails, and the Siri "add transaction" shortcut fails gracefully when the device is locked.
- **Notification/Info.plist hardening** — removed the unused `remote-notification` background mode.

Also fixes two real bugs found while chasing flaky PIN tests: a production `AuthenticationWrapper.onAppear` path that was clearing Keychain PIN state when run as the unit-test host process, and a PIN entry UX bug where a correct PIN didn't clear the input field.

## Testing

- 393/393 automated tests passing (Swift Testing), confirmed clean twice in a row.
- Reviewed via subagent-driven development (per-task + whole-branch review) plus an independent Opus-model review of the full diff — no blocking findings.
- Manual on-device verification still needed (simulator can't exercise these): PIN lockout escalation across expiry, cross-device iCloud Keychain backup restore, screen recording capture guard, and the locked-device Siri shortcut path.

## Out of scope

The "Forgot PIN" unlock bypass (`BiometricAuthService.authenticate()` short-circuits to unlocked when `isLockEnabled` is false) is a separate, higher-severity fix tracked on its own.