### PR TITLE
fix: sheet doesn't follow appearance switch to Auto

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/App/PersonalFinanceTrakerApp.swift
@@ -80,8 +80,22 @@ private extension PersonalFinanceTrakerApp {
     func applyAppearance(_ mode: ThemeMode) {
         for scene in UIApplication.shared.connectedScenes {
             guard let windowScene = scene as? UIWindowScene else { continue }
+            // A presented (not embedded) controller reliably re-renders when its
+            // override is set to a *concrete* .light/.dark — that's the path Light
+            // and Dark already use. Setting `.unspecified` on a presented controller
+            // removes the override but doesn't reliably force it to re-resolve from
+            // its ambient trait, so Auto needs a resolved concrete value here too.
+            // The window itself keeps `.unspecified` for Auto — the root hierarchy
+            // (not a presented controller) does track system changes live via that.
+            let resolvedForPresented: UIUserInterfaceStyle =
+                mode == .auto ? windowScene.traitCollection.userInterfaceStyle : mode.uiStyle
             for window in windowScene.windows {
                 window.overrideUserInterfaceStyle = mode.uiStyle
+                var presented = window.rootViewController?.presentedViewController
+                while let controller = presented {
+                    controller.overrideUserInterfaceStyle = resolvedForPresented
+                    presented = controller.presentedViewController
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes a regression from #23: switching the appearance picker directly between Light and Dark updated an already-open Settings sheet correctly, but switching *to* Auto left it on its previous appearance.

## Root cause

`applyAppearance` restyles the presented sheet chain by setting `overrideUserInterfaceStyle` on each controller. Concrete `.light`/`.dark` forces a resolved-trait change and reliably re-renders. `.unspecified` (what Auto maps to) removes the override instead of forcing one, and on an already-presented controller that doesn't reliably trigger a re-render.

## Fix

For Auto, resolve the system's current style (`windowScene.traitCollection.userInterfaceStyle`) and force that concrete value onto the presented sheet chain — reusing the same mechanism that already works for Light/Dark. The window itself keeps `.unspecified` for Auto, since the root app hierarchy already tracks system changes correctly on its own; only the presented sheet needed the workaround.

## Known limitation

This makes the sheet's Auto appearance a snapshot taken at the moment Auto is selected. If the system appearance flips while Auto is active *and* the sheet is still open, the sheet won't live-update again — a narrower, different bug than the one being fixed here.

## Verification

Build clean via Xcode MCP. Verified on device: Dark→Auto and Light→Auto with the Settings sheet open, in both directions.
