### PR TITLE
chore: add worktree-safe xcodebuild workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,16 +25,23 @@ Personal Finance Tracker is a SwiftUI iOS app for income, expense, budget, insig
 
 ## Build And Test
 
-- Prefer the Xcode MCP connector if it is available in the current Codex session. Load deferred schemas with `tool_search` first, then call the exposed Xcode tools.
-- Current Claude tool names, when available in Claude Code, are:
-  - Build: `mcp__xcode__BuildProject`
-  - Run all tests: `mcp__xcode__RunAllTests`
-  - Run specific tests: `mcp__xcode__RunSomeTests`
-  - Build/test log: `mcp__xcode__GetBuildLog`
-  - Test list: `mcp__xcode__GetTestList`
-- Active Claude tab identifier is `windowtab1`.
+Use the `xcodebuild` CLI by default. The Xcode MCP hangs forever on a crashed test, requires Xcode open and connected, and silently builds the wrong worktree when `tabIdentifier` gets reassigned.
+
+```bash
+scripts/xcb build
+scripts/xcb test
+scripts/xcb test -only-testing:PersonalFinanceTrakerTests/SearchTests
+scripts/xcb which-sim    # print this worktree's simulator name + UDID
+scripts/xcb clean-sims   # delete leftover "Clone N of ..." simulators
+scripts/xcb delete-sim   # drop this worktree's dedicated simulator
+```
+
+- `scripts/xcb test` prints only a JSON summary; the full log goes to `.build/test.log`.
+- Run builds and tests in the background and poll for completion; a full run takes several minutes.
+- Everything is per-worktree with no configuration: `-derivedDataPath .build` is relative (`.build/` is gitignored), and the script creates a simulator named `pft-<worktree-dir>` on first use so concurrent agents never share a device. `PFT_SIM_UDID=<udid>` overrides it.
+- Never hardcode a simulator OS version. `simctl`'s runtime identifier is rounded (`iOS-26-4`) while the real version is `26.4.1`, and a bare `name=iPhone 17` destination expands to `OS:latest`, which can resolve to a runtime with no such device. The script targets the device by UDID. Hand-written destinations should come from `xcodebuild -showdestinations`.
+- The Xcode MCP stays available for when Xcode is already open on a single checkout. Claude tool names: `mcp__xcode__BuildProject`, `mcp__xcode__RunAllTests`, `mcp__xcode__RunSomeTests`, `mcp__xcode__GetBuildLog`, `mcp__xcode__GetTestList`; load deferred schemas first and verify the tab identifier with `mcp__xcode__XcodeListWindows`, matching on `WorkspacePath`.
 - Do not invoke MCP tool names as shell commands.
-- Do not run shell `xcodebuild` unless the user explicitly asks for it or approves it for the turn.
 
 ## App Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,33 +12,31 @@ This repository is configured for both Claude Code and Codex.
 
 ## Build & Development Commands
 
-**CRITICAL — BUILD & TEST RULES:**
-- **NEVER run `xcodebuild` in Bash.** It is banned. Use Xcode MCP tools only.
-- **NEVER call MCP tool names as Bash commands.** `mcp__xcode__BuildProject` is not a shell command.
-- MCP tools are deferred — their schemas must be loaded with `ToolSearch` before they can be called.
+**Use the `xcodebuild` CLI. It is the default for agents.** The Xcode MCP is optional and has three failure modes that cost real time:
 
-**Exact two-step sequence every time:**
+- A **crashed test** leaves the MCP waiting forever — no exit code, no timeout. The agent gets stuck polling.
+- It **requires Xcode open and connected**. The CLI is headless.
+- With **worktrees**, `tabIdentifier` gets reassigned between windows and the MCP silently builds the *wrong worktree*.
 
-Step 1 — load the schema via `ToolSearch`:
-```
-query: "select:mcp__xcode__BuildProject,mcp__xcode__RunAllTests,mcp__xcode__RunSomeTests"
-```
-
-Step 2 — call the tool with `tabIdentifier: "windowtab1"`:
-```
-mcp__xcode__BuildProject(tabIdentifier: "windowtab1")
-mcp__xcode__RunAllTests(tabIdentifier: "windowtab1")
+```bash
+scripts/xcb build
+scripts/xcb test
+scripts/xcb test -only-testing:PersonalFinanceTrakerTests/SearchTests
+scripts/xcb which-sim    # print this worktree's simulator name + UDID
+scripts/xcb clean-sims   # delete leftover "Clone N of ..." simulators
+scripts/xcb delete-sim   # drop this worktree's dedicated simulator
 ```
 
-| Task | MCP tool name |
-|------|--------------|
-| Build | `mcp__xcode__BuildProject` |
-| Run all tests | `mcp__xcode__RunAllTests` |
-| Run specific tests | `mcp__xcode__RunSomeTests` |
-| Get build/test log | `mcp__xcode__GetBuildLog` |
-| List available tests | `mcp__xcode__GetTestList` |
+`scripts/xcb test` prints only a JSON summary (counts, failed test names, messages); the full log goes to `.build/test.log`. Read that file only when the summary is not enough.
 
-The active `tabIdentifier` is always `"windowtab1"`.
+**Run builds and tests in the background** (`run_in_background: true`), then wait with a `Monitor` until-loop. A full test run takes several minutes and will otherwise eat a foreground timeout.
+
+Notes:
+- **Everything is per-worktree, no configuration.** `-derivedDataPath .build` is relative, so each worktree gets its own build tree (`.build/` is gitignored), and the script creates its own simulator named `pft-<worktree-dir>` on first use, so concurrent agents never share a device. `PFT_SIM_UDID=<udid>` overrides it.
+- **Never hardcode a simulator OS version.** `simctl`'s runtime *identifier* is rounded (`iOS-26-4`) while its real version is `26.4.1`, and a bare `name=iPhone 17` destination expands to `OS:latest`, which can resolve to a runtime that has no such device. The script targets the device by UDID, which avoids both. If you write a destination by hand, get it from `xcodebuild -showdestinations`, never from `simctl list devices`.
+- **Never call MCP tool names as Bash commands.** `mcp__xcode__BuildProject` is not a shell command.
+
+**If you do use the MCP** (Xcode already open, single checkout): schemas are deferred, so load them with `ToolSearch` first — `query: "select:mcp__xcode__BuildProject,mcp__xcode__RunAllTests"` — then call with `tabIdentifier: "windowtab1"`. Verify the identifier with `mcp__xcode__XcodeListWindows` first; match on `WorkspacePath`, not the first hit.
 
 **Note**: The project is primarily developed in Xcode. Open `PersonalFinanceTraker/PersonalFinanceTraker.xcodeproj` to work in the IDE.
 

--- a/scripts/xcb
+++ b/scripts/xcb
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Build/test wrapper for agents, CI, and humans. See CLAUDE.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PROJECT=PersonalFinanceTraker/PersonalFinanceTraker.xcodeproj
+SCHEME=PersonalFinanceTraker
+DEVICE_TYPE=com.apple.CoreSimulator.SimDeviceType.iPhone-17
+RESULT=.build/Test.xcresult
+
+# One simulator per worktree, named after the worktree directory, so concurrent
+# agents never share a device. Override with PFT_SIM_UDID to reuse an existing one.
+SIM_NAME="pft-$(basename "$PWD")"
+
+# Never hardcode an OS version: simctl's runtime *identifier* is rounded
+# (iOS-26-4) while its actual version is 26.4.1, and a bare device name resolves
+# to OS:latest, which may be a runtime that has no such device. Targeting the
+# device by UDID sidesteps name and version resolution entirely.
+resolve_sim() {
+  if [ -n "${PFT_SIM_UDID:-}" ]; then echo "$PFT_SIM_UDID"; return; fi
+
+  local udid
+  udid=$(xcrun simctl list devices -j | SIM_NAME="$SIM_NAME" python3 -c '
+import json, os, sys
+want = os.environ["SIM_NAME"]
+for group in json.load(sys.stdin)["devices"].values():
+    for d in group:
+        if d["name"] == want and d.get("isAvailable"):
+            print(d["udid"]); sys.exit(0)
+')
+  if [ -n "$udid" ]; then echo "$udid"; return; fi
+
+  # Newest available iOS runtime that actually supports this device type.
+  local runtime
+  runtime=$(xcrun simctl list runtimes -j | DEVICE_TYPE="$DEVICE_TYPE" python3 -c '
+import json, os, sys
+want = os.environ["DEVICE_TYPE"]
+best = None
+for r in json.load(sys.stdin)["runtimes"]:
+    if not r.get("isAvailable"): continue
+    if not r["identifier"].startswith("com.apple.CoreSimulator.SimRuntime.iOS-"): continue
+    if want not in [d["identifier"] for d in r.get("supportedDeviceTypes", [])]: continue
+    key = tuple(int(p) for p in r["version"].split("."))
+    if best is None or key > best[0]: best = (key, r["identifier"])
+print(best[1] if best else "")
+')
+  if [ -z "$runtime" ]; then
+    echo "xcb: no available iOS runtime supports $DEVICE_TYPE" >&2
+    echo "xcb: check Xcode > Settings > Components" >&2
+    exit 1
+  fi
+  xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE" "$runtime"
+}
+
+udids_named() {  # $1 = python expression over the device name `n` (os, SIM_NAME in scope)
+  xcrun simctl list devices -j 2>/dev/null | PRED="$1" SIM_NAME="$SIM_NAME" python3 -c '
+import json, os, sys
+pred = eval("lambda n: " + os.environ["PRED"])
+for group in json.load(sys.stdin)["devices"].values():
+    for d in group:
+        if pred(d["name"]): print(d["udid"])
+' 2>/dev/null || true
+}
+
+# xcodebuild leaves "Clone N of <device>" simulators behind when a parallel test
+# run crashes or is interrupted; it cleans up after itself on a normal exit.
+delete_clones() {
+  udids_named 'n.startswith("Clone ")' | while read -r udid; do
+    xcrun simctl delete "$udid" >/dev/null 2>&1 || true
+  done
+}
+
+case "${1:-}" in
+  build)
+    shift
+    xcodebuild build \
+      -project "$PROJECT" -scheme "$SCHEME" \
+      -destination "id=$(resolve_sim)" \
+      -derivedDataPath .build -quiet "$@"
+    ;;
+
+  test)
+    shift
+    trap delete_clones EXIT
+    rm -rf "$RESULT"   # xcodebuild refuses to overwrite an existing bundle
+    mkdir -p .build    # the log redirect below needs it on a fresh worktree
+    status=0
+    # -quiet still prints a line per test case, so the log goes to a file and only
+    # the summary reaches stdout. Read .build/test.log when you need detail.
+    xcodebuild test \
+      -project "$PROJECT" -scheme "$SCHEME" \
+      -destination "id=$(resolve_sim)" \
+      -derivedDataPath .build \
+      -resultBundlePath "$RESULT" \
+      -test-timeouts-enabled YES \
+      -maximum-test-execution-time-allowance 120 \
+      -quiet "$@" >.build/test.log 2>&1 || status=$?
+    if [ -d "$RESULT" ]; then
+      xcrun xcresulttool get test-results summary --path "$RESULT"
+    else
+      tail -40 .build/test.log   # died before producing a bundle
+    fi
+    exit $status
+    ;;
+
+  clean-sims)
+    delete_clones
+    ;;
+
+  delete-sim)   # drop this worktree's dedicated device
+    udids_named 'n == os.environ["SIM_NAME"]' | while read -r udid; do
+      xcrun simctl delete "$udid"
+    done
+    ;;
+
+  which-sim)
+    echo "$SIM_NAME $(resolve_sim)"
+    ;;
+
+  *)
+    echo "usage: scripts/xcb {build|test|clean-sims|delete-sim|which-sim} [extra xcodebuild args]" >&2
+    echo "  scripts/xcb test -only-testing:PersonalFinanceTrakerTests/SearchTests" >&2
+    echo "  PFT_SIM_UDID=<udid> scripts/xcb test   # target a specific simulator" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add a worktree-scoped xcodebuild build/test wrapper.
- Document the CLI-first workflow for Codex and Claude.
- Retain optional MCP guidance for single-checkout Xcode usage.

## Validation
- bash -n scripts/xcb
- git diff --check main...HEAD

Scope: CLAUDE.md, AGENTS.md, and scripts/xcb only. Unrelated staged notification documents are excluded.