### PR TITLE
Fix category name validation for common punctuation

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/AddCategorySheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/AddCategorySheet.swift
@@ -25,8 +25,8 @@ struct AddCategorySheet: View {
 
     private var nameError: String? {
         if name.isEmpty { return nil }
-        if name.range(of: #"^[a-zA-Z0-9 ]+$"#, options: .regularExpression) == nil {
-            return "Only letters, numbers and spaces allowed"
+        if !CategoryNameValidator.isValid(name) {
+            return "Use letters, numbers, spaces, and common punctuation"
         }
         if existingCategories.contains(where: { $0.name.lowercased() == name.lowercased() }) {
             return "A category with this name already exists"

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/EditCategorySheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/EditCategorySheet.swift
@@ -15,8 +15,8 @@ struct EditCategorySheet: View {
     private var nameError: String? {
         let trimmed = editedName.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty { return "Name cannot be empty" }
-        if trimmed.range(of: #"^[a-zA-Z0-9 ]+$"#, options: .regularExpression) == nil {
-            return "Only letters, numbers and spaces allowed"
+        if !CategoryNameValidator.isValid(trimmed) {
+            return "Use letters, numbers, spaces, and common punctuation"
         }
         if existingCategories.contains(where: {
             $0.id != category.id && $0.name.lowercased() == trimmed.lowercased()

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/ImportCategorySetupSheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/ImportCategorySetupSheet.swift
@@ -41,8 +41,8 @@ struct ImportCategorySetupSheet: View {
 
     private var nameError: String? {
         guard !trimmedName.isEmpty else { return nil }
-        if trimmedName.range(of: #"^[a-zA-Z0-9 ]+$"#, options: .regularExpression) == nil {
-            return "Only letters, numbers and spaces allowed"
+        if !CategoryNameValidator.isValid(trimmedName) {
+            return "Use letters, numbers, spaces, and common punctuation"
         }
         let normalizedName = trimmedName.lowercased()
         if existingNames.contains(normalizedName) || otherDraftNames.contains(normalizedName) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/CategoryNameValidator.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/CategoryNameValidator.swift
@@ -1,0 +1,20 @@
+//
+//  CategoryNameValidator.swift
+//  PersonalFinanceTraker
+//
+
+import Foundation
+
+enum CategoryNameValidator {
+    private static let allowedCharacters: CharacterSet = {
+        var characters = CharacterSet.letters
+        characters.formUnion(.decimalDigits)
+        characters.formUnion(.whitespaces)
+        characters.formUnion(CharacterSet(charactersIn: "&/-'.,()"))
+        return characters
+    }()
+
+    static func isValid(_ name: String) -> Bool {
+        name.unicodeScalars.allSatisfy(allowedCharacters.contains)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryNameValidatorTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryNameValidatorTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import PersonalFinanceTraker
+
+struct CategoryNameValidatorTests {
+    @Test("Accepts CSV-compatible category names with common punctuation")
+    func acceptsCommonPunctuation() {
+        #expect(CategoryNameValidator.isValid("Photography & Videomaking"))
+        #expect(CategoryNameValidator.isValid("Rent/Mortgage"))
+        #expect(CategoryNameValidator.isValid("Kids' Activities - Summer"))
+        #expect(CategoryNameValidator.isValid("Caffè, Bar (Downtown)"))
+    }
+
+    @Test("Rejects unsupported category characters")
+    func rejectsUnsupportedCharacters() {
+        #expect(!CategoryNameValidator.isValid("Food < Groceries"))
+        #expect(!CategoryNameValidator.isValid("Bills @ Home"))
+    }
+}


### PR DESCRIPTION
## Summary
- allow common punctuation and Unicode letters in category names
- use one validator for add, edit, and CSV-import category flows
- add coverage for ampersands and other valid punctuation

## Testing
- scripts/xcb test -only-testing:PersonalFinanceTrakerTests/CategoryNameValidatorTests

Closes #48