### PR TITLE
Fix #47: scope category name uniqueness per transaction type

### DIFF
--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/AddCategorySheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/AddCategorySheet.swift
@@ -28,7 +28,10 @@ struct AddCategorySheet: View {
         if !CategoryNameValidator.isValid(name) {
             return "Use letters, numbers, spaces, and common punctuation"
         }
-        if existingCategories.contains(where: { $0.name.lowercased() == name.lowercased() }) {
+        let sameTypeNames = existingCategories
+            .filter { $0.transactionType == selectedType }
+            .map { $0.name }
+        if CategoryNameValidator.isDuplicate(name, among: sameTypeNames) {
             return "A category with this name already exists"
         }
         return nil

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/EditCategorySheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/CategorySettings/EditCategorySheet.swift
@@ -18,9 +18,10 @@ struct EditCategorySheet: View {
         if !CategoryNameValidator.isValid(trimmed) {
             return "Use letters, numbers, spaces, and common punctuation"
         }
-        if existingCategories.contains(where: {
-            $0.id != category.id && $0.name.lowercased() == trimmed.lowercased()
-        }) {
+        let sameTypeNames = existingCategories
+            .filter { $0.id != category.id && $0.transactionType == category.transactionType }
+            .map { $0.name }
+        if CategoryNameValidator.isDuplicate(trimmed, among: sameTypeNames) {
             return "A category with this name already exists"
         }
         return nil

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/CSVCategoryMappingView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/CSVCategoryMappingView.swift
@@ -126,12 +126,10 @@ struct CSVCategoryMappingView: View {
             ImportCategorySetupSheet(
                 draft: draft,
                 lockedType: categoryTypes[draft.csvCategory],
-                existingNames: Set(availableCategories.map { $0.name.lowercased() }),
-                otherDraftNames: Set(
-                    viewModel.pendingCategoryDrafts
-                        .filter { $0.key != draft.csvCategory }
-                        .map { $0.value.name.trimmingCharacters(in: .whitespaces).lowercased() }
-                ),
+                existingCategories: availableCategories,
+                otherDrafts: viewModel.pendingCategoryDrafts
+                    .filter { $0.key != draft.csvCategory }
+                    .map { $0.value },
                 onSave: { savedDraft in
                     viewModel.pendingCategoryDrafts[savedDraft.csvCategory] = savedDraft
                     selections[savedDraft.csvCategory] = newSentinel

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/ImportCategorySetupSheet.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/ImportCategorySetupSheet.swift
@@ -10,8 +10,8 @@ struct ImportCategorySetupSheet: View {
 
     let csvCategory: String
     let lockedType: TransactionType?
-    let existingNames: Set<String>
-    let otherDraftNames: Set<String>
+    let existingCategories: [CategorySnapshot]
+    let otherDrafts: [ImportCategoryDraft]
     let onSave: (ImportCategoryDraft) -> Void
 
     @State private var draft: ImportCategoryDraft
@@ -19,14 +19,14 @@ struct ImportCategorySetupSheet: View {
     init(
         draft: ImportCategoryDraft,
         lockedType: TransactionType?,
-        existingNames: Set<String>,
-        otherDraftNames: Set<String>,
+        existingCategories: [CategorySnapshot],
+        otherDrafts: [ImportCategoryDraft],
         onSave: @escaping (ImportCategoryDraft) -> Void
     ) {
         self.csvCategory = draft.csvCategory
         self.lockedType = lockedType
-        self.existingNames = existingNames
-        self.otherDraftNames = otherDraftNames
+        self.existingCategories = existingCategories
+        self.otherDrafts = otherDrafts
         self.onSave = onSave
         var initialDraft = draft
         if let lockedType {
@@ -44,8 +44,14 @@ struct ImportCategorySetupSheet: View {
         if !CategoryNameValidator.isValid(trimmedName) {
             return "Use letters, numbers, spaces, and common punctuation"
         }
-        let normalizedName = trimmedName.lowercased()
-        if existingNames.contains(normalizedName) || otherDraftNames.contains(normalizedName) {
+        let sameTypeExistingNames = existingCategories
+            .filter { $0.transactionType == draft.type }
+            .map { $0.name }
+        let sameTypeDraftNames = otherDrafts
+            .filter { $0.type == draft.type }
+            .map { $0.name }
+        if CategoryNameValidator.isDuplicate(trimmedName, among: sameTypeExistingNames)
+            || CategoryNameValidator.isDuplicate(trimmedName, among: sameTypeDraftNames) {
             return "A category with this name already exists"
         }
         return nil

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/TransactionListViewModel.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/TransactionListViewModel.swift
@@ -799,11 +799,15 @@ final class TransactionListViewModel {
             }
 
             // Step 3: Map CSV category names to persistentIds for newly created categories
+            // Matched on name AND type: "Other" can now exist for both Expense and Income,
+            // so name alone could bind an Income row to the Expense category.
             for (csvCatName, selection) in categoryResolutionSelections {
                 guard selection == "__new__" else { continue }
-                let createdName = pendingCategoryDrafts[csvCatName]?.name
-                    ?? ImportCategoryDraft(csvCategory: csvCatName, inferredType: csvCategoryTypes[csvCatName]).name
-                if let catSnapshot = updatedCategories.first(where: { $0.name == createdName }) {
+                let createdDraft = pendingCategoryDrafts[csvCatName]
+                    ?? ImportCategoryDraft(csvCategory: csvCatName, inferredType: csvCategoryTypes[csvCatName])
+                if let catSnapshot = updatedCategories.first(where: {
+                    $0.name == createdDraft.name && $0.transactionType == createdDraft.type
+                }) {
                     newCategoryPersistentIds[csvCatName] = catSnapshot.persistentId
                 }
             }
@@ -813,9 +817,11 @@ final class TransactionListViewModel {
             if let signature = currentImportSignature {
                 var resolvedSelections = categoryResolutionSelections
                 for (csvCatName, selection) in resolvedSelections where selection == "__new__" {
-                    let createdName = pendingCategoryDrafts[csvCatName]?.name
-                        ?? ImportCategoryDraft(csvCategory: csvCatName, inferredType: csvCategoryTypes[csvCatName]).name
-                    if let created = updatedCategories.first(where: { $0.name == createdName }) {
+                    let createdDraft = pendingCategoryDrafts[csvCatName]
+                        ?? ImportCategoryDraft(csvCategory: csvCatName, inferredType: csvCategoryTypes[csvCatName])
+                    if let created = updatedCategories.first(where: {
+                        $0.name == createdDraft.name && $0.transactionType == createdDraft.type
+                    }) {
                         resolvedSelections[csvCatName] = created.id.uuidString
                     }
                 }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Models/TransactionCategory.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Models/TransactionCategory.swift
@@ -27,6 +27,7 @@ struct TransactionCategory: Identifiable, Hashable, Codable {
         TransactionCategory(systemImage: "star.circle", label: "Bonus"),
         TransactionCategory(systemImage: "trophy", label: "Prize"),
         TransactionCategory(systemImage: "arrow.uturn.backward", label: "Refund"),
+        TransactionCategory(systemImage: "ellipsis.circle", label: "Other"),
     ]
 
     static let expenseCategories: [TransactionCategory] = [

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/CategoryNameValidator.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/CategoryNameValidator.swift
@@ -17,4 +17,11 @@ enum CategoryNameValidator {
     static func isValid(_ name: String) -> Bool {
         name.unicodeScalars.allSatisfy(allowedCharacters.contains)
     }
+
+    /// Names are unique **per type** — Expense and Income can each own an "Other".
+    /// Callers pass the names already filtered to the relevant transaction type.
+    static func isDuplicate(_ name: String, among names: some Sequence<String>) -> Bool {
+        let normalized = name.trimmingCharacters(in: .whitespaces).lowercased()
+        return names.contains { $0.trimmingCharacters(in: .whitespaces).lowercased() == normalized }
+    }
 }

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/TransactionListView/TransactionListViewModelTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Features/TransactionListView/TransactionListViewModelTests.swift
@@ -126,6 +126,55 @@ struct TransactionListViewModelTests {
         #expect(category.colorToken == "categoryPurple")
     }
 
+    // Regression for #47: Expense and Income can each have their own "Other" category, so
+    // resolving a "__new__" selection must match on name AND type, not name alone.
+    @Test @MainActor func importedCategoryResolvesToMatchingTypeWhenNameIsShared() async throws {
+        let schema = Schema([TransactionModel.self, CategoryModel.self, GoalModel.self, RecurrenceRule.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        let container = try! ModelContainer(for: schema, configurations: [config])
+        let actor = TransactionActor(modelContainer: container)
+
+        // An expense "Other" already exists before the import creates the income one.
+        try! await actor.addCategory(CategoryInput(
+            name: "Other", systemImage: "ellipsis.circle", type: "expense",
+            colorToken: "categoryGray", monthlyBudget: nil, currencyCode: "EUR"
+        ))
+
+        let vm = TransactionListViewModel(repo: actor)
+        vm.load()
+        await vm.loadTask?.value
+
+        let csvCategory = "Altro"
+        vm.categoryResolutionSelections = [csvCategory: "__new__"]
+        vm.pendingCategoryDrafts = [
+            csvCategory: ImportCategoryDraft(
+                csvCategory: csvCategory,
+                name: "Other",
+                type: .income,
+                systemImage: "ellipsis.circle",
+                colorToken: "categoryGray"
+            )
+        ]
+
+        let input = TransactionInput(
+            timestamp: Date(), amount: 42, note: "Rimborso",
+            category: csvCategory, currencyCode: "EUR"
+        )
+        vm.confirmImport([input])
+        await vm.importTask?.value
+
+        // importError doubles as the success-summary field ("Imported 1 transaction."); only
+        // fail-shaped messages ("Failed to...") indicate a real problem here.
+        #expect(vm.importError?.hasPrefix("Failed") != true)
+        let categories = try await vm.repo.fetchCategories()
+        #expect(categories.filter { $0.name == "Other" }.count == 2)
+
+        let transactions = try await vm.repo.fetchAll()
+        let imported = try #require(transactions.first { $0.note == "Rimborso" })
+        let boundCategory = try #require(categories.first { $0.persistentId == imported.categoryId })
+        #expect(boundCategory.transactionType == TransactionType.income)
+    }
+
     @Test @MainActor func reconcilingImportCategoriesDropsObsoleteDrafts() async {
         let vm = TransactionListViewModel(repo: MockTransactionRepository())
         vm.categoryResolutionSelections = ["Current": "__new__", "Removed": "__new__"]

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryAutoMapperTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryAutoMapperTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import PersonalFinanceTraker
+
+struct CategoryAutoMapperTests {
+    // Regression for #47: an Income "Other" must be offered instead of falling through to
+    // "__new__" — that's what makes the import flow stop prompting to create a duplicate.
+    @Test("Auto-map offers the existing Income Other instead of prompting to create one")
+    func resolvesAltroToExistingIncomeOther() {
+        let expenseOther = CategorySnapshot.test(name: "Other", type: .expense)
+        let incomeOther = CategorySnapshot.test(name: "Other", type: .income)
+
+        let selections = CategoryAutoMapper.resolve(
+            csvCategories: ["Altro"],
+            categoryTypes: ["Altro": .income],
+            availableCategories: [expenseOther, incomeOther],
+            existing: [:]
+        )
+
+        #expect(selections["Altro"] == incomeOther.id.uuidString)
+        #expect(selections["Altro"] != CategoryAutoMapper.newSentinel)
+    }
+}

--- a/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryNameValidatorTests.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTrakerTests/Utilities/CategoryNameValidatorTests.swift
@@ -15,4 +15,17 @@ struct CategoryNameValidatorTests {
         #expect(!CategoryNameValidator.isValid("Food < Groceries"))
         #expect(!CategoryNameValidator.isValid("Bills @ Home"))
     }
+
+    @Test("Detects duplicates case- and whitespace-insensitively")
+    func detectsDuplicates() {
+        #expect(CategoryNameValidator.isDuplicate("Other", among: ["Other"]))
+        #expect(CategoryNameValidator.isDuplicate("  other ", among: ["Other"]))
+        #expect(CategoryNameValidator.isDuplicate("OTHER", among: ["Groceries", "Other"]))
+    }
+
+    @Test("No match when the name isn't among the given names")
+    func noDuplicateWhenAbsent() {
+        #expect(!CategoryNameValidator.isDuplicate("Other", among: ["Groceries", "Salary"]))
+        #expect(!CategoryNameValidator.isDuplicate("Other", among: []))
+    }
 }


### PR DESCRIPTION
## Problem

During CSV import, an unmapped Income category (e.g. "Altro") pre-fills a new-category form named "Other". "Other" already exists as an Expense default, but every duplicate-name check compared names globally, so the app either created a second, confusing "Other" or blocked saving with "A category with this name already exists" — even though no Income "Other" existed yet.

TestFlight feedback: `AFWO2d0i6If5vMMmhniVZHU` — "Other is already present for expenses category, not for income category".

## Fix

Category name uniqueness is now scoped per type — Expense and Income can each own their own "Other".

- `CategoryNameValidator.isDuplicate`: shared, case/whitespace-insensitive duplicate check
- `AddCategorySheet` / `EditCategorySheet` / `ImportCategorySetupSheet`: duplicate checks now filter to the category's own type
- `TransactionCategory.incomeCategories`: added a default Income "Other" so fresh installs auto-map "Altro" to it instead of prompting to create one
- `TransactionListViewModel.confirmImport`: write-back now matches newly created categories by name **and** type, so it can't bind an Income row to the Expense "Other"

## Testing

- `scripts/xcb build` — clean
- `scripts/xcb test` — full suite green (513/513)
- New tests: `CategoryNameValidatorTests` (duplicate detection), `TransactionListViewModelTests.importedCategoryResolvesToMatchingTypeWhenNameIsShared` (write-back binds by type), `CategoryAutoMapperTests.resolvesAltroToExistingIncomeOther` (auto-map offers the existing Income Other instead of prompting)

Closes #47