### PR TITLE
fix: iPad sidebar layout + shake-to-hide (#51, #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ section to TestFlight as "What to Test" and archives it under the build
 number that shipped it.
 
 ## Unreleased
+- iPad: Activity's filter chips and transaction table now resize to fit alongside the sidebar instead of being hidden behind it.
+- iPad: shaking the device now hides amounts like it does on iPhone, and there's a new eye icon on iPad to hide/show amounts without shaking.
 
 ## 76 — 2026-08-27
 - Fixed keyboard focus jumping in the Add/Edit Transaction and Goal sheets.

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/MainTabView/MainTabView.swift
@@ -24,8 +24,6 @@ struct MainTabView: View {
     @State private var compassViewModel: CompassViewModel
     @State private var profileViewModel: ProfileViewModel
     @State private var dataChanged: DataChangedSignal
-    @State private var showPrivacyToast = false
-    @State private var privacyToastTask: Task<Void, Never>?
     private let repo: TransactionActor
     private let materializationService: RecurrenceMaterializationService
     // Owned by AuthenticationWrapper (not MainTabView) so hideAmounts survives the
@@ -150,20 +148,8 @@ struct MainTabView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .overlay(alignment: .top) {
-            if showPrivacyToast {
-                ToastBanner(
-                    icon: appSettings.hideAmounts ? "eye.slash.fill" : "eye.fill",
-                    message: appSettings.hideAmounts ? String(localized: "Amounts hidden") : String(localized: "Amounts shown")
-                ) { EmptyView() }
-                    .accessibilityElement(children: .combine)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-            }
-        }
         .animation(.spring(duration: 0.3), value: viewModel.showUndoBanner)
-        .animation(.spring(duration: 0.3), value: showPrivacyToast)
+        .hideAmountsShortcut(appSettings)
         .onChange(of: selectedTab) { _, newTab in
             shellModels.selectedTab = newTab
         }
@@ -229,17 +215,6 @@ struct MainTabView: View {
             consumePendingAdd()
             consumePendingHabitTemplate()
             consumePendingWidgetDestination()
-        }
-        .onShake {
-            appSettings.toggleHideAmounts()
-        }
-        .onChange(of: appSettings.hideAmounts) { _, _ in
-            privacyToastTask?.cancel()
-            showPrivacyToast = true
-            privacyToastTask = Task {
-                try? await Task.sleep(for: .seconds(1.5))
-                if !Task.isCancelled { showPrivacyToast = false }
-            }
         }
         .onChange(of: PendingTransactionIntent.shared.shouldPresentAdd) { _, pending in
             if pending { consumePendingAdd() }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadLedgerTable.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadLedgerTable.swift
@@ -61,6 +61,8 @@ struct IPadLedgerTable: View {
     private var ledger: some View {
         table
             .tableStyle(.inset)
+        .frame(maxWidth: .infinity)
+        .clipped()
         .scrollContentBackground(.hidden)
         .contextMenu(forSelectionType: TransactionSnapshot.ID.self) { ids in
             contextMenu(for: ids)
@@ -143,17 +145,22 @@ struct IPadLedgerTable: View {
     /// Split out from `body`, and every cell extracted into its own small view, because the
     /// combined `Table` + four columns + modifier chain repeatedly blew the type-checker's
     /// time budget as one expression.
+    /// Column minimums have to stay small enough that their sum — plus the selection column and
+    /// the inset style's padding — fits the detail column of a *portrait* iPad with the sidebar
+    /// shown (~420pt on the smaller devices). When they don't, the Table lays out wider than its
+    /// column and paints leftward underneath the sidebar instead of compressing (issue #51).
+    /// Current sum is ~344pt; keep it under ~380 if a column is ever added.
     private var table: some View {
         Table(rows, selection: selection, sortOrder: $sortOrder) {
             TableColumn("Date", value: \.timestamp) { item in
                 DateCell(date: item.timestamp)
             }
-            .width(min: 80, ideal: 110, max: 150)
+            .width(min: 64, ideal: 100, max: 150)
 
             TableColumn("Description", value: \.note) { item in
                 DescriptionCell(note: item.note, category: item.category)
             }
-            .width(min: 160)
+            .width(min: 100)
 
             TableColumn("Category", value: \.category) { item in
                 CategoryCell(
@@ -162,12 +169,12 @@ struct IPadLedgerTable: View {
                     colorToken: item.categoryColorToken
                 )
             }
-            .width(min: 140, ideal: 180)
+            .width(min: 90, ideal: 160)
 
             TableColumn("Amount", value: \.amount) { item in
                 AmountCell(amount: item.amount, currencyCode: item.currencyCode)
             }
-            .width(min: 110, ideal: 140, max: 200)
+            .width(min: 90, ideal: 130, max: 200)
         }
     }
 

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadRootView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadRootView.swift
@@ -33,6 +33,9 @@ struct IPadRootView: View {
             content
         }
         .navigationSplitViewStyle(.balanced)
+        // Shake never reached this shell before (only MainTabView had .onShake attached), and
+        // shaking an iPad isn't a comfortable gesture anyway — issue #52.
+        .hideAmountsShortcut(appSettings)
         .inspector(isPresented: inspectorPresented) {
             IPadInspector(models: models, showingAddItemView: $showingAddItemView)
                 .inspectorColumnWidth(min: 320, ideal: 400, max: 560)
@@ -149,24 +152,33 @@ struct IPadRootView: View {
 
     @ViewBuilder
     private var content: some View {
-        switch section ?? .home {
-        case .home:
-            IPadDashboardGrid(showingAddItemView: $showingAddItemView)
-        case .activity:
-            IPadLedgerTable(showingAddItemView: $showingAddItemView)
-        case .goals:
-            IPadGoalsView(viewModel: models.compass)
-        case .recurring:
-            IPadRecurringSection(materializationService: models.materializationService)
-        case .insights:
-            CompassView(viewModel: models.compass, showingAddItemView: $showingAddItemView)
-        case .healthScore:
-            IPadHealthScoreView(viewModel: models.compass)
-        case .settings:
-            NavigationStack {
-                ProfileView(viewModel: models.profile, selectedDetent: $profileDetent, isHostedAsSheet: false)
-                    .navigationTitle("Settings")
-                    .appBackground()
+        Group {
+            switch section ?? .home {
+            case .home:
+                IPadDashboardGrid(showingAddItemView: $showingAddItemView)
+            case .activity:
+                IPadLedgerTable(showingAddItemView: $showingAddItemView)
+            case .goals:
+                IPadGoalsView(viewModel: models.compass)
+            case .recurring:
+                IPadRecurringSection(materializationService: models.materializationService)
+            case .insights:
+                CompassView(viewModel: models.compass, showingAddItemView: $showingAddItemView)
+            case .healthScore:
+                IPadHealthScoreView(viewModel: models.compass)
+            case .settings:
+                NavigationStack {
+                    ProfileView(viewModel: models.profile, selectedDetent: $profileDetent, isHostedAsSheet: false)
+                        .navigationTitle("Settings")
+                        .appBackground()
+                }
+            }
+        }
+        // On the detail column, not the sidebar, so it stays reachable even when the sidebar is
+        // collapsed (compact width / user-collapsed) — issue #52's "always-visible CTA" ask.
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                HideAmountsButton()
             }
         }
     }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadRootView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/iPad/IPadRootView.swift
@@ -132,6 +132,7 @@ struct IPadRootView: View {
             }
         }
         .navigationTitle("Finance")
+        .navigationSplitViewColumnWidth(min: 200, ideal: 260, max: 320)
         .scrollContentBackground(.hidden)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/HideAmountsControl.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/HideAmountsControl.swift
@@ -1,0 +1,67 @@
+//
+//  HideAmountsControl.swift
+//  PersonalFinanceTraker
+//
+
+import SwiftUI
+
+/// Always-visible CTA for toggling `AppSettings.hideAmounts`, matching the eye icon on Home's
+/// `BalanceCardView`. Shake-to-hide (`onShake`, wired via `hideAmountsShortcut`) previously was
+/// the iPhone-only path to this; #52 asked for a discoverable control that doesn't depend on the
+/// shake gesture working (it doesn't reach `IPadRootView` at all — no window override installs a
+/// shake handler for that shell) or being comfortable on a device iPad-sized.
+struct HideAmountsButton: View {
+    @Environment(AppSettings.self) private var appSettings
+
+    var body: some View {
+        Button {
+            appSettings.toggleHideAmounts()
+        } label: {
+            Image(systemName: appSettings.hideAmounts ? "eye.slash" : "eye")
+        }
+        .accessibilityLabel(appSettings.hideAmounts ? String(localized: "Show amounts") : String(localized: "Hide amounts"))
+    }
+}
+
+/// Shake-to-toggle plus the "Amounts hidden/shown" toast, lifted out of `MainTabView` so
+/// `IPadRootView` can opt into the same behaviour (issue #52 — shake previously only worked on
+/// the iPhone shell since `.onShake` was never attached to the iPad one).
+private struct HideAmountsShortcut: ViewModifier {
+    let appSettings: AppSettings
+    @State private var showPrivacyToast = false
+    @State private var privacyToastTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .top) {
+                if showPrivacyToast {
+                    ToastBanner(
+                        icon: appSettings.hideAmounts ? "eye.slash.fill" : "eye.fill",
+                        message: appSettings.hideAmounts ? String(localized: "Amounts hidden") : String(localized: "Amounts shown")
+                    ) { EmptyView() }
+                        .accessibilityElement(children: .combine)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(duration: 0.3), value: showPrivacyToast)
+            .onShake {
+                appSettings.toggleHideAmounts()
+            }
+            .onChange(of: appSettings.hideAmounts) { _, _ in
+                privacyToastTask?.cancel()
+                showPrivacyToast = true
+                privacyToastTask = Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    if !Task.isCancelled { showPrivacyToast = false }
+                }
+            }
+    }
+}
+
+extension View {
+    func hideAmountsShortcut(_ appSettings: AppSettings) -> some View {
+        modifier(HideAmountsShortcut(appSettings: appSettings))
+    }
+}


### PR DESCRIPTION
## Fixes

Closes #51, Closes #52

### #51 — iPad sidebar overlays content
- `IPadLedgerTable`: shrink table column minimums so the Activity ledger fits a portrait iPad's detail column instead of overflowing under the sidebar; clip the table to its frame as a hard backstop.
- `IPadRootView`: give the sidebar an explicit `navigationSplitViewColumnWidth` instead of the unconstrained platform default.

### #52 — Shake-to-hide doesn't work on iPad
- New `Utilities/HideAmountsControl.swift`: `HideAmountsButton` (matches Home's balance-card eye) and a `hideAmountsShortcut()` modifier carrying the shake gesture + privacy toast, extracted out of `MainTabView` so both shells can use it.
- `MainTabView` switches to `hideAmountsShortcut()` — iPhone behavior unchanged (still shake + Home's balance-card eye, no new toolbar icon there).
- `IPadRootView` wires `hideAmountsShortcut()` (shake never reached this shell before) and adds the eye button to the detail column's toolbar, so it stays visible even with the sidebar collapsed.

## Testing
- `scripts/xcb build` and `scripts/xcb test` — 519/519 passing.
- Manual iPad simulator check of Activity layout (portrait/landscape) and the hide-amounts toggle.