### PR TITLE
Fix Italian analysis labels and Settings theme refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ section to TestFlight as "What to Test" and archives it under the build
 number that shipped it.
 
 ## Unreleased
+- Italian now covers Settings discovery and Analysis labels, and the Settings close button immediately follows a theme change.
 - iPad: Activity's filter chips and transaction table now resize to fit alongside the sidebar instead of being hidden behind it.
 - iPad: shaking the device now hides amounts like it does on iPhone, and there's a new eye icon on iPad to hide/show amounts without shaking.
 

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/CategoryTrendRow.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Insights/Components/CategoryTrendRow.swift
@@ -34,7 +34,11 @@ struct CategoryTrendRow: View {
                         .font(.body)
                         .foregroundStyle(.textPrimary)
                         .lineLimit(1)
-                    Text(String(format: "%.1f%% of total", trend.category.percentage))
+                    Text(String(
+                        format: String(localized: "%.1f%% of total"),
+                        locale: .current,
+                        trend.category.percentage
+                    ))
                         .font(.caption)
                         .foregroundStyle(.textDim)
                 }
@@ -67,7 +71,7 @@ struct CategoryTrendRow: View {
     private var trendBadge: some View {
         if trend.isNew {
             return AnyView(
-                Text("new")
+                Text(String(localized: "new"))
                     .font(.caption.bold())
                     .foregroundStyle(.textDim)
                     .padding(.horizontal, 6)

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/Profile/Views/ProfileView.swift
@@ -21,6 +21,7 @@ struct ProfileView: View {
     @Environment(DataChangedSignal.self) private var dataChanged
     @Environment(AppSettings.self) private var appSettings
     @Environment(FeatureDiscoveryCoordinator.self) private var featureDiscovery
+    @Environment(\.colorScheme) private var colorScheme
     @State private var showingFileImporter = false
     @State private var showingDeleteConfirmation = false
     @State private var showingPINConfirmation = false
@@ -307,6 +308,10 @@ struct ProfileView: View {
                                 .padding(8)
                         }
                         .accessibilityLabel("Close")
+                        // SwiftUI can retain toolbar content across an appearance change. Give
+                        // this color-sensitive control a new identity so its semantic color is
+                        // resolved again as soon as Settings switches themes.
+                        .id(colorScheme)
                     }
                 }
             }

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/TimePeriodPicker.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Features/TransactionListView/Components/TimePeriodPicker.swift
@@ -26,6 +26,14 @@ public enum TimePeriod: String, CaseIterable {
     var description: String {
         return rawValue
     }
+
+    var localizedLabel: LocalizedStringKey {
+        switch self {
+        case .week: "Week"
+        case .month: "Month"
+        case .year: "Year"
+        }
+    }
 }
 
 /// A reusable segmented picker component for selecting time periods in financial views
@@ -57,7 +65,7 @@ public struct TimePeriodPicker: View {
     public var body: some View {
         Picker("Time Period", selection: $selection) {
             ForEach(TimePeriod.allCases, id: \.self) { period in
-                Text(period.rawValue).tag(period)
+                Text(period.localizedLabel).tag(period)
             }
         }
         .pickerStyle(SegmentedPickerStyle())

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Localizable.xcstrings
@@ -3092,8 +3092,39 @@
         }
       }
     },
+    "%.1f%% of total" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f%% of total"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f%% del totale"
+          }
+        }
+      }
+    },
     "DISCOVER" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DISCOVER"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SCOPRI"
+          }
+        }
+      }
     },
     "Dismiss" : {
       "extractionState" : "manual",
@@ -3711,7 +3742,21 @@
       }
     },
     "Explore the App" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explore the App"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora l’app"
+          }
+        }
+      }
     },
     "Export Data" : {
       "extractionState" : "manual",
@@ -4213,7 +4258,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Punteggio di salute"
+            "value" : "Situazione finanziaria"
           }
         }
       }
@@ -9093,8 +9138,90 @@
         }
       }
     },
+    "Week" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settimana"
+          }
+        }
+      }
+    },
+    "Week %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settimana %lld"
+          }
+        }
+      }
+    },
+    "Month" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Month"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mese"
+          }
+        }
+      }
+    },
+    "Year" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anno"
+          }
+        }
+      }
+    },
     "What's New" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What's New"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novità"
+          }
+        }
+      }
     },
     "Which category?" : {
       "comment" : "Label for the category parameter in the Add Transaction intent.",

--- a/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ChartDataService.swift
+++ b/PersonalFinanceTraker/PersonalFinanceTraker/Utilities/ChartDataService.swift
@@ -78,7 +78,7 @@ class ChartDataService {
             let income = calculateIncome(from: weekItems)
             let expenses = calculateExpenses(from: weekItems)
 
-            data.append(ChartDataPoint(period: "Week \(weekNumber)", income: income, expenses: expenses, date: weekStart))
+            data.append(ChartDataPoint(period: String(localized: "Week \(weekNumber)"), income: income, expenses: expenses, date: weekStart))
             weekStart = weekEnd
             weekNumber += 1
         }


### PR DESCRIPTION
## Summary
- Fixes #53: localize the Settings Discover section and Analysis period, chart, percentage, and trend labels in Italian; rename the Italian Health Score label to Situazione finanziaria.
- Fixes #57: refresh the Settings close button when the appearance changes.

## Validation
- Device-SDK build succeeded with xcodebuild for the PersonalFinanceTraker scheme.

## Notes
- Generated graph artifacts were intentionally left out of this PR.